### PR TITLE
chore: remove pinned versions for ubuntu security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,6 @@ RUN apt-get update && \
         libmagic1 \
         # Dependency for opencv library
         libgl1 \
-        # Install security fixes
-        libc-bin=2.39-0ubuntu8.4 \
-        libc6=2.39-0ubuntu8.4 \
-        libgnutls30t64=3.8.3-1.1ubuntu3.3 \
-        libtasn1-6=4.19.0-3ubuntu0.24.04.1 \
-        libraptor2-0=2.0.16-3ubuntu0.1 \
-        libgssapi-krb5-2=1.20.1-6ubuntu2.5 \
-        libk5crypto3=1.20.1-6ubuntu2.5 \
-        libkrb5-3=1.20.1-6ubuntu2.5 \
-        libkrb5support0=1.20.1-6ubuntu2.5 \
         && \
     # Cleanup apt cache in the same command to reduce size
     apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Description of changes

- remove pinned versions for ubuntu security fixes - base image already includes the fixes, and some pinned versions are not available anymore
- fixes failed job https://github.com/epam/ai-dial-rag/actions/runs/15394250216/job/43311381559

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
