### PR TITLE
chore: update .dockerignore for github

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,20 +8,25 @@
 !docker_compose_local
 !docs
 !eval
-!helm
 !tests
 !.dockerignore
+!.env.example
+!.github
 !.gitignore
-!.gitlab
-!.gitlab-ci.yml
+!.vscode/extensions.json
+!CONTRIBUTING.md
 !Dockerfile
+!LICENSE
+!Makefile
 !README.md
+!SECURITY.md
 !collect_repository_digest.py
 !download_model.py
 !noxfile.py
 !poetry.lock
 !poetry.toml
 !pyproject.toml
+!trivy.yaml
 
 
 # Include git repository to collect repository digest
@@ -29,7 +34,6 @@
 
 
 # Exclude files within included folders
-**/.vscode
 **/.pytest_cache
 **/.env
 **/.venv


### PR DESCRIPTION
### Description of changes

The .dockerignore file was not updated after migration to github, which makes repository digest to think that there are local modifications, and look like this:
```
Repository digest version: 391fd25-dirty
Repository digest status: D .env.example
 D .github/CODEOWNERS
 D .github/ISSUE_TEMPLATE/01_bug_report.yml
 D .github/ISSUE_TEMPLATE/02_feature_request.yml
 D .github/ISSUE_TEMPLATE/config.yml
 D .github/dependabot.yml
 D .github/pull_request_template.md
 D .github/workflows/cleanup-untagged-images.yml
 D .github/workflows/deploy-development.yml
 D .github/workflows/pr-title-check.yml
 D .github/workflows/pr.yml
 D .github/workflows/release.yml
 D .github/workflows/slash-command-dispatch.yml
 D .vscode/extensions.json
 D CONTRIBUTING.md
 D LICENSE
 D Makefile
 D SECURITY.md
 D trivy.yaml
```
Updating the .dockerignore to fix this.


### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
