### PR TITLE
fix: use ThreadPoolExecutor instead of ProcessPoolExecutor

### DIFF
--- a/tests/test_cpu_pools.py
+++ b/tests/test_cpu_pools.py
@@ -1,10 +1,7 @@
 import pytest
 from aidial_sdk import HTTPException
 
-from aidial_rag.resources.cpu_pools import (
-    UnpicklableExceptionError,
-    run_in_indexing_cpu_pool,
-)
+from aidial_rag.resources.cpu_pools import run_in_indexing_cpu_pool
 
 
 class TestException(Exception):
@@ -34,12 +31,9 @@ async def test_picklable_exception():
 
 @pytest.mark.asyncio
 async def test_unpicklable_exception():
-    with pytest.raises(UnpicklableExceptionError) as exc_info:
+    with pytest.raises(TestException) as exc_info:
         await run_in_indexing_cpu_pool(function_with_unpicklable_exception)
-
-    assert isinstance(exc_info.value, UnpicklableExceptionError)
-    assert "Unpicklable exception raised in subprocess" in str(exc_info.value)
-    assert "This exception is not picklable" in str(exc_info.value.__cause__)
+    assert exc_info.value.message == "This exception is not picklable"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Applicable issues

- fixes #11 

### Description of changes

- Replacing ProcessPoolExecutor with ThreadPoolExecutor for indexing_cpu_pool.
ProcessPoolExecutor is unable to recover the child processes in case of issues like OOM and could be left in broken state. With the ThreadPoolExecutor the main process will fail in such cases, and could be restarted by kubernetes.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
