### PR TITLE
feat: add timeout configuration for check document access

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,29 @@ Ignore errors during document loading. Used for Web RAG for the request with mul
 
 Use profiler to collect performance metrics for the request.
 
-##### `DIAL_RAG__REQUEST__INDEXING__DOWNLOAD__TIMEOUT_SECONDS`
+##### `DIAL_RAG__REQUEST__DOWNLOAD__TIMEOUT_SECONDS`
 
 *Optional*, default value: `30`
 
-HTTP client timeout for downloading the content of the document.
+Timeout for the whole request. Includes connection establishment, sending the request, and receiving the response.
+
+##### `DIAL_RAG__REQUEST__DOWNLOAD__CONNECT_TIMEOUT_SECONDS`
+
+*Optional*, default value: `30`
+
+Timeout for establishing a connection to the server.
+
+##### `DIAL_RAG__REQUEST__CHECK_ACCESS__TIMEOUT_SECONDS`
+
+*Optional*, default value: `30`
+
+Timeout for the whole request. Includes connection establishment, sending the request, and receiving the response.
+
+##### `DIAL_RAG__REQUEST__CHECK_ACCESS__CONNECT_TIMEOUT_SECONDS`
+
+*Optional*, default value: `30`
+
+Timeout for establishing a connection to the server.
 
 ##### `DIAL_RAG__REQUEST__INDEXING__PARSER__MAX_DOCUMENT_TEXT_SIZE`
 
@@ -142,7 +160,7 @@ Enables MultimodalRetriever which uses multimodal embedding models for pages ima
 
 ##### `DIAL_RAG__REQUEST__INDEXING__DESCRIPTION_INDEX`
 
-*Optional*, default value: `llm=LlmConfig(deployment_name='gpt-4o-mini-2024-07-18', max_prompt_tokens=0, max_retries=3) estimated_task_tokens=4000 time_limit_multiplier=1.5 min_time_limit_sec=300`
+*Optional*, default value: `llm=LlmConfig(deployment_name='gpt-4o-mini-2024-07-18', max_prompt_tokens=0, max_retries=1000000000) estimated_task_tokens=4000 time_limit_multiplier=1.5 min_time_limit_sec=300`
 
 Enables DescriptionRetriever which uses vision model to generate page images descriptions and perform search on them.
 

--- a/aidial_rag/app.py
+++ b/aidial_rag/app.py
@@ -295,7 +295,7 @@ class DialRAGApplication(ChatCompletion):
                 request_context,
                 attachment_links,
                 self.index_storage,
-                index_config=request_config.indexing,
+                config=request_config,
             )
             document_records, loading_errors = process_load_errors(
                 docs_and_errors, attachment_links

--- a/aidial_rag/app_config.py
+++ b/aidial_rag/app_config.py
@@ -13,7 +13,10 @@ from aidial_rag.base_config import (
     IndexRebuildTrigger,
     collect_fields_with_trigger,
 )
-from aidial_rag.document_loaders import DownloadConfig, ParserConfig
+from aidial_rag.document_loaders import (
+    HttpClientConfig,
+    ParserConfig,
+)
 from aidial_rag.document_record import IndexSettings
 from aidial_rag.index_storage import IndexStorageConfig
 from aidial_rag.llm import LlmConfig
@@ -28,8 +31,6 @@ from aidial_rag.retrievers.multimodal_retriever import MultimodalIndexConfig
 
 class IndexingConfig(BaseConfig):
     """Configuration for the document indexing."""
-
-    download: DownloadConfig = Field(default=DownloadConfig())
 
     # pyright does not understand default values for Annotated fields
     parser: ParserConfig = Field(default=ParserConfig())  # type: ignore
@@ -73,6 +74,16 @@ class RequestConfig(BaseConfig):
     use_profiler: bool = Field(
         default=False,
         description="Use profiler to collect performance metrics for the request.",
+    )
+
+    download: HttpClientConfig = Field(
+        default=HttpClientConfig(),
+        description="Configuration for downloading the attached documents.",
+    )
+
+    check_access: HttpClientConfig = Field(
+        default=HttpClientConfig(),
+        description="Configuration for checking access to the documents in the Dial.",
     )
 
     indexing: IndexingConfig = Field(default=IndexingConfig())

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -12,7 +12,6 @@ def test_multimodal_index_settings():
 
     index_settings = config.request.indexing.collect_fields_that_rebuild_index()
     assert index_settings.indexes == {
-        "download": {},
         "multimodal_index": {
             "embeddings_model": "multimodalembedding@001",
         },
@@ -27,7 +26,6 @@ def test_description_index_settings():
 
     index_settings = config.request.indexing.collect_fields_that_rebuild_index()
     assert index_settings.indexes == {
-        "download": {},
         "description_index": {},
         "parser": {
             "unstructured_chunk_size": 1000,

--- a/tests/test_attachment_stored.py
+++ b/tests/test_attachment_stored.py
@@ -4,7 +4,7 @@ import pytest
 from aidial_sdk.chat_completion import Choice, Stage
 from pydantic import SecretStr
 
-from aidial_rag.app_config import IndexingConfig
+from aidial_rag.app_config import IndexingConfig, RequestConfig
 from aidial_rag.attachment_link import AttachmentLink
 from aidial_rag.document_loaders import load_attachment
 from aidial_rag.document_record import DocumentRecord
@@ -15,7 +15,9 @@ from aidial_rag.request_context import RequestContext
 from aidial_rag.resources.dial_limited_resources import DialLimitedResources
 from tests.utils.user_limits_mock import user_limits_mock
 
-index_config = IndexingConfig(multimodal_index=None, description_index=None)
+request_config = RequestConfig(
+    indexing=IndexingConfig(multimodal_index=None, description_index=None),
+)
 
 
 @pytest.fixture
@@ -94,12 +96,12 @@ async def test_load_document_success(
         request_context,
         attachment_link,
         index_storage,
-        index_config=index_config,
+        config=request_config,
     )
     assert isinstance(doc_record, DocumentRecord)
     assert doc_record.document_bytes == b"This is a test byte array."
 
-    index_settings = index_config.collect_fields_that_rebuild_index()
+    index_settings = request_config.indexing.collect_fields_that_rebuild_index()
 
     # Read stored value
     doc = await index_storage.load(
@@ -136,5 +138,5 @@ async def test_load_document_invalid_document(
             request_context,
             attachment_link,
             index_storage,
-            index_config=index_config,
+            config=request_config,
         )


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #13 

### Description of changes

- add configurable request timeout and connection timeout for check_document_access (requesting document metadata from Dial)
- add configurable connection timeout for download_attachment
- fixed the bug that download_config was not passed to download_attachment
- download_config was moved from IndexingConfig to RequestConfig, so that download_config and check_access configs do not affect `indexing.collect_fields_that_rebuild_index()`. Technically changing `DIAL_RAG__REQUEST__INDEXING__DOWNLOAD__TIMEOUT_SECONDS` to `DIAL_RAG__REQUEST__DOWNLOAD__TIMEOUT_SECONDS` is a breaking change. But, since there was a bug and this parameter was not passed to the download_attachment, I think no one used it for now.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
