### PR TITLE
feat: allow to write document links to logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ Ignore errors during document loading. Used for Web RAG for the request with mul
 
 Use profiler to collect performance metrics for the request.
 
+##### `DIAL_RAG__REQUEST__ALLOW_LOG_DOCUMENT_LINKS`
+
+*Optional*, default value: `False`
+
+Allows to write the links of the attached documents to the logs with log level higher than DEBUG.
+
 ##### `DIAL_RAG__REQUEST__DOWNLOAD__TIMEOUT_SECONDS`
 
 *Optional*, default value: `30`

--- a/README.md
+++ b/README.md
@@ -116,11 +116,15 @@ Ignore errors during document loading. Used for Web RAG for the request with mul
 
 Use profiler to collect performance metrics for the request.
 
-##### `DIAL_RAG__REQUEST__ALLOW_LOG_DOCUMENT_LINKS`
+##### `DIAL_RAG__REQUEST__LOG_DOCUMENT_LINKS`
 
 *Optional*, default value: `False`
 
-Allows to write the links of the attached documents to the logs with log level higher than DEBUG.
+Allows writing the links of the attached documents to the logs with log levels higher than DEBUG.
+
+If enabled, Dial RAG will log the links to the documents for log messages with levels from INFO to CRITICAL where relevant. For example, an ERROR log message with an exception during document processing will contain the link to the document.
+
+If disabled, only log messages with DEBUG level may contain the links to the documents, to avoid logging sensitive information. For example, the links to the documents will not be logged for the ERROR log messages with an exception during document processing.
 
 ##### `DIAL_RAG__REQUEST__DOWNLOAD__TIMEOUT_SECONDS`
 

--- a/aidial_rag/app_config.py
+++ b/aidial_rag/app_config.py
@@ -76,6 +76,12 @@ class RequestConfig(BaseConfig):
         description="Use profiler to collect performance metrics for the request.",
     )
 
+    allow_log_document_links: bool = Field(
+        default=False,
+        description="Allows to write the links of the attached documents to the logs "
+        "with log level higher than DEBUG.",
+    )
+
     download: HttpClientConfig = Field(
         default=HttpClientConfig(),
         description="Configuration for downloading the attached documents.",

--- a/aidial_rag/app_config.py
+++ b/aidial_rag/app_config.py
@@ -76,10 +76,18 @@ class RequestConfig(BaseConfig):
         description="Use profiler to collect performance metrics for the request.",
     )
 
-    allow_log_document_links: bool = Field(
+    log_document_links: bool = Field(
         default=False,
-        description="Allows to write the links of the attached documents to the logs "
-        "with log level higher than DEBUG.",
+        description="Allows writing the links of the attached documents to the logs "
+        "with log levels higher than DEBUG.\n\n"
+        "If enabled, Dial RAG will log the links to the documents for log messages "
+        "with levels from INFO to CRITICAL where relevant. For example, an ERROR log "
+        "message with an exception during document processing will contain the link "
+        "to the document.\n\n"
+        "If disabled, only log messages with DEBUG level may contain the links to "
+        "the documents, to avoid logging sensitive information. For example, the links "
+        "to the documents will not be logged for the ERROR log messages with an exception "
+        "during document processing.",
     )
 
     download: HttpClientConfig = Field(

--- a/aidial_rag/content_stream.py
+++ b/aidial_rag/content_stream.py
@@ -20,9 +20,40 @@ class StreamWithPrefix:
         self.prefix = prefix
 
     def write(self, content):
-        if content == "\n" or content == "":
-            # avoid prefixing empty lines, like on tqdm.close() calls
+        if not content.strip(" \n"):
+            # Avoid prefixing empty lines, like on tqdm.close() calls
             return
-        message = f"{self.prefix} {content}"
-        logger.info(f"{message}")
-        self.stream.write(f"{message}\n\n")
+        self.stream.write(f"{self.prefix} {content}")
+
+
+class StageStream:
+    def __init__(self, stream: SupportsWriteStr):
+        self.stream = stream
+
+    def write(self, content):
+        # Use double new line for markdown formatting
+        self.stream.write(f"{content}\n\n")
+
+
+class LoggerStream:
+    def __init__(
+        self, logger: logging.Logger = logger, log_level: int = logging.INFO
+    ):
+        self.logger = logger
+        self.log_level = log_level
+
+    def write(self, content):
+        message = content.strip(" \n")
+        if not message:
+            # Avoid logging empty lines
+            return
+        self.logger.log(self.log_level, f"{message}")
+
+
+class MultiStream:
+    def __init__(self, *streams: SupportsWriteStr):
+        self.streams = streams
+
+    def write(self, content):
+        for stream in self.streams:
+            stream.write(content)

--- a/aidial_rag/content_stream.py
+++ b/aidial_rag/content_stream.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 # _typeshed module is not available at runtime, so we need to use a string literal
@@ -26,7 +26,7 @@ class StreamWithPrefix:
         self.stream.write(f"{self.prefix} {content}")
 
 
-class StageStream:
+class MarkdownStream:
     def __init__(self, stream: SupportsWriteStr):
         self.stream = stream
 
@@ -37,17 +37,14 @@ class StageStream:
 
 class LoggerStream:
     def __init__(
-        self, logger: logging.Logger = logger, log_level: int = logging.INFO
+        self, logger: logging.Logger = _logger, log_level: int = logging.INFO
     ):
         self.logger = logger
         self.log_level = log_level
 
     def write(self, content):
-        message = content.strip(" \n")
-        if not message:
-            # Avoid logging empty lines
-            return
-        self.logger.log(self.log_level, f"{message}")
+        if message := content.strip(" \n"):
+            self.logger.log(self.log_level, f"{message}")
 
 
 class MultiStream:

--- a/aidial_rag/errors.py
+++ b/aidial_rag/errors.py
@@ -50,6 +50,26 @@ class NotEnoughDailyTokensError(HTTPException):
         super().__init__(message, status_code=400)
 
 
+class DocumentProcessingError(HTTPException):
+    """Represents an error that occurred during the processing of the attached document."""
+
+    def __init__(
+        self,
+        link: str,
+        exception: Exception,
+        allow_log_document_links: bool = False,
+    ):
+        if allow_log_document_links:
+            message = f"Error on processing document {link}: {exception}"
+        else:
+            message = f"Error on processing document: {exception}"
+
+        if isinstance(exception, HTTPException):
+            super().__init__(message, exception.status_code)
+        else:
+            super().__init__(message)
+
+
 @contextmanager
 def log_exceptions(logger: logging.Logger | None = None):
     if logger is None:

--- a/tests/test_app_errors.py
+++ b/tests/test_app_errors.py
@@ -1,0 +1,154 @@
+import json
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from aidial_rag.app import create_app
+from aidial_rag.app_config import AppConfig
+from tests.utils.e2e_decorator import e2e_test
+
+MIDDLEWARE_HOST = "http://localhost:8081"
+
+
+def _make_test_request(question, attachments) -> str:
+    app = create_app(app_config=AppConfig(dial_url=MIDDLEWARE_HOST))
+    client = TestClient(app)
+    response = client.post(
+        "/openai/deployments/dial-rag/chat/completions",
+        headers={"Api-Key": "api-key"},
+        json={
+            "model": "dial-rag",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": question,
+                    "custom_content": {"attachments": attachments},
+                }
+            ],
+        },
+        timeout=100.0,
+    )
+    assert response.status_code == 200
+    json_response = json.loads(response.text)
+    return json_response["choices"][0]["message"]["content"]
+
+
+@pytest.mark.asyncio
+@e2e_test(filenames=["test_file.csv"])
+async def test_document_error(attachments, caplog):
+    message = _make_test_request("What is this csv about?", attachments)
+    assert (
+        "I'm sorry, but I can't process the documents because of the following errors:\n\n"
+        "|Document|Error|\n"
+        "|---|---|\n"
+        "|test_file.csv|Unable to load document content. Try another document format.|\n\n"
+        "Please try again with different documents." in message
+    )
+
+    assert "test_file.csv" not in caplog.text
+    assert "Parser:  Parsing document started" in caplog.text
+
+    assert (
+        "aidial_rag.errors.DocumentProcessingError: Error on processing document: "
+        "unhandled errors in a TaskGroup (1 sub-exception)" in caplog.text
+    )
+    assert (
+        "aidial_sdk.exceptions.HTTPException: Unable to load document content. "
+        "Try another document format." in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+@e2e_test(filenames=["test_file.csv"])
+async def test_document_error_with_error_log_enabled(attachments, caplog):
+    with patch.dict(
+        "os.environ",
+        {
+            "DIAL_RAG__REQUEST__ALLOW_LOG_DOCUMENT_LINKS": "true",
+        },
+    ):
+        message = _make_test_request("What is this csv about?", attachments)
+
+    assert (
+        "I'm sorry, but I can't process the documents because of the following errors:\n\n"
+        "|Document|Error|\n"
+        "|---|---|\n"
+        "|test_file.csv|Unable to load document content. Try another document format.|\n\n"
+        "Please try again with different documents." in message
+    )
+
+    assert "test_file.csv" in caplog.text
+    assert (
+        "<files/6iTkeGUs2CvUehhYLmMYXB/test_file.csv>:  Parser:  Parsing document started"
+        in caplog.text
+    )
+
+    assert (
+        "aidial_rag.errors.DocumentProcessingError: Error on processing document "
+        "files/6iTkeGUs2CvUehhYLmMYXB/test_file.csv: "
+        "unhandled errors in a TaskGroup (1 sub-exception)" in caplog.text
+    )
+    assert (
+        "aidial_sdk.exceptions.HTTPException: Unable to load document content. "
+        "Try another document format." in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+@e2e_test(filenames=["test_file.csv"])
+async def test_wrong_filename(attachments, caplog):
+    attachments[0]["url"] = attachments[0]["url"].replace(".csv", ".xls")
+    message = _make_test_request("What is this csv about?", attachments)
+
+    assert (
+        "I'm sorry, but I can't process the documents because of the following errors:\n\n"
+        "|Document|Error|\n"
+        "|---|---|\n"
+        "|test_file.xls|404 Not Found|\n\n"
+        "Please try again with different documents." in message
+    )
+
+    assert "test_file.xls" not in caplog.text
+    assert "Parser:  Parsing document started" not in caplog.text
+
+    assert (
+        "aidial_rag.errors.DocumentProcessingError: Error on processing document: 404 Not Found"
+        in caplog.text
+    )
+    assert (
+        "aidial_rag.errors.InvalidDocumentError: 404 Not Found" in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+@e2e_test(filenames=["test_file.csv"])
+async def test_wrong_filename_with_error_log_enabled(attachments, caplog):
+    with patch.dict(
+        "os.environ",
+        {
+            "DIAL_RAG__REQUEST__ALLOW_LOG_DOCUMENT_LINKS": "true",
+        },
+    ):
+        attachments[0]["url"] = attachments[0]["url"].replace(".csv", ".xls")
+        message = _make_test_request("What is this csv about?", attachments)
+
+    assert (
+        "I'm sorry, but I can't process the documents because of the following errors:\n\n"
+        "|Document|Error|\n"
+        "|---|---|\n"
+        "|test_file.xls|404 Not Found|\n\n"
+        "Please try again with different documents." in message
+    )
+
+    assert "test_file.xls" in caplog.text
+    assert "Parser:  Parsing document started" not in caplog.text
+
+    assert (
+        "aidial_rag.errors.DocumentProcessingError: Error on processing document "
+        "files/6iTkeGUs2CvUehhYLmMYXB/test_file.xls: 404 Not Found"
+        in caplog.text
+    )
+    assert (
+        "aidial_rag.errors.InvalidDocumentError: 404 Not Found" in caplog.text
+    )

--- a/tests/test_app_errors.py
+++ b/tests/test_app_errors.py
@@ -65,7 +65,7 @@ async def test_document_error_with_error_log_enabled(attachments, caplog):
     with patch.dict(
         "os.environ",
         {
-            "DIAL_RAG__REQUEST__ALLOW_LOG_DOCUMENT_LINKS": "true",
+            "DIAL_RAG__REQUEST__LOG_DOCUMENT_LINKS": "true",
         },
     ):
         message = _make_test_request("What is this csv about?", attachments)
@@ -127,7 +127,7 @@ async def test_wrong_filename_with_error_log_enabled(attachments, caplog):
     with patch.dict(
         "os.environ",
         {
-            "DIAL_RAG__REQUEST__ALLOW_LOG_DOCUMENT_LINKS": "true",
+            "DIAL_RAG__REQUEST__LOG_DOCUMENT_LINKS": "true",
         },
     ):
         attachments[0]["url"] = attachments[0]["url"].replace(".csv", ".xls")

--- a/tests/test_attachment_stored.py
+++ b/tests/test_attachment_stored.py
@@ -9,7 +9,7 @@ from aidial_rag.attachment_link import AttachmentLink
 from aidial_rag.document_loaders import load_attachment
 from aidial_rag.document_record import DocumentRecord
 from aidial_rag.documents import load_document
-from aidial_rag.errors import InvalidDocumentError
+from aidial_rag.errors import DocumentProcessingError, InvalidDocumentError
 from aidial_rag.index_storage import IndexStorage
 from aidial_rag.request_context import RequestContext
 from aidial_rag.resources.dial_limited_resources import DialLimitedResources
@@ -133,10 +133,11 @@ async def test_load_document_invalid_document(
         MagicMock(), 0, 0, name
     )
 
-    with pytest.raises(InvalidDocumentError):
+    with pytest.raises(DocumentProcessingError) as exc_info:
         await load_document(
             request_context,
             attachment_link,
             index_storage,
             config=request_config,
         )
+    assert isinstance(exc_info.value.__cause__, InvalidDocumentError)

--- a/tests/utils/cache_middleware.py
+++ b/tests/utils/cache_middleware.py
@@ -9,7 +9,7 @@ from typing import Dict
 
 import httpx
 import pytest
-from fastapi import APIRouter, FastAPI, Request, Response
+from fastapi import APIRouter, FastAPI, HTTPException, Request, Response
 from pydantic.dataclasses import dataclass
 
 from tests.utils.cache_response import CacheResponse
@@ -135,6 +135,8 @@ class CacheMiddlewareApp(FastAPI):
                 request_query=path,
                 request_body="",
             )
+        except FileNotFoundError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
         except Exception as e:
             logger.exception(f"Error processing metadata for {file_name}: {e}")
             raise


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #22 

### Description of changes

- Introduce new configuration parameter DIAL_RAG__REQUEST__LOG_DOCUMENT_LINKS which will allow Dial RAG to write the links of the processed documents to the logs with loglevels other that DEBUG
- StreamWithPrefix was split to several components to accommodate flexible configuration.
- Document link will be added to the log messages corresponding to the document processing stage if the option is enabled.
- DocumentProcessingError was added to retain an information about the processed document together with an error cause. 
- Document link will be added to the exception message if the option is enabled.
- e2e_test was changed to support caplog fixture to check the log messages in the test.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
