### PR TITLE
fix: disable show_progress for embeddings

### DIFF
--- a/aidial_rag/embeddings/embeddings.py
+++ b/aidial_rag/embeddings/embeddings.py
@@ -60,7 +60,7 @@ def bge_embedding_impl() -> HuggingFaceBgeEmbeddings:
         encode_kwargs={
             "normalize_embeddings": True,
         },
-        show_progress=True,
+        show_progress=False,
     )
     bge_embedding_impl.client.compile()
     return bge_embedding_impl


### PR DESCRIPTION
### Description of changes

- Disable progress reporting from the HuggingFaceBgeEmbeddings. It breaks the log format and is not useful, because it reports progress only within the batch. We have separate progress mechanism in batched_map_with_progress to report the progress of the processing of the whole document.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
