### PR TITLE
fix: extract retrieval to a separate chain

### DIFF
--- a/aidial_rag/app.py
+++ b/aidial_rag/app.py
@@ -29,12 +29,14 @@ from aidial_rag.documents import load_documents
 from aidial_rag.index_record import ChunkMetadata, RetrievalType
 from aidial_rag.index_storage import IndexStorage
 from aidial_rag.qa_chain import generate_answer
+from aidial_rag.query_chain import create_get_query_chain
 from aidial_rag.repository_digest import (
     RepositoryDigest,
     read_repository_digest,
 )
 from aidial_rag.request_context import create_request_context
 from aidial_rag.resources.cpu_pools import init_cpu_pools
+from aidial_rag.retrieval_chain import create_retrieval_chain
 from aidial_rag.retrievers.all_documents_retriever import AllDocumentsRetriever
 from aidial_rag.retrievers.bm25_retriever import BM25Retriever
 from aidial_rag.retrievers.description_retriever.description_retriever import (
@@ -46,6 +48,7 @@ from aidial_rag.retrievers.multimodal_retriever import (
 )
 from aidial_rag.retrievers.semantic_retriever import SemanticRetriever
 from aidial_rag.stages import RetrieverStage
+from aidial_rag.transform_history import transform_history
 from aidial_rag.utils import profiler_if_enabled, timed_stage
 
 APP_NAME = "dial-rag"
@@ -208,6 +211,26 @@ def get_configuration(request: Request) -> dict:
     return custom_configuration_dict
 
 
+async def _run_rag(
+    request_context, choice, request_config, retrieval_chain, chain_input
+):
+    reference_items = await generate_answer(
+        request_context=request_context,
+        request_config=request_config,
+        retrieval_chain=retrieval_chain,
+        chain_input=chain_input,
+        content_callback=choice.append_content,
+    )
+
+    document_records = chain_input["doc_records"]
+    # Answer has already been streamed to the user, so we don't need to do anything here.
+    for i, reference_item in enumerate(reference_items):
+        if attachment := doc_to_attach(
+            reference_item, document_records, index=(i + 1)
+        ):
+            choice.add_attachment(**attachment)
+
+
 class DialRAGApplication(ChatCompletion):
     app_config: AppConfig
     index_storage: IndexStorage
@@ -310,16 +333,6 @@ class DialRAGApplication(ChatCompletion):
                 )
                 return
 
-            with timed_stage(choice, "Prepare indexes for search"):
-                retriever = await loop.run_in_executor(
-                    None,
-                    create_retriever,
-                    request_context.choice,
-                    request_context.dial_config,
-                    document_records,
-                    request_config.indexing.multimodal_index,
-                )
-
             last_message_content = messages[-1].content
             if last_message_content is None:
                 return
@@ -331,22 +344,40 @@ class DialRAGApplication(ChatCompletion):
             if not last_message_content.strip():
                 return
 
-            with profiler_if_enabled(choice, request_config.use_profiler):
-                reference_items = await generate_answer(
-                    request_context=request_context,
-                    qa_chain_config=request_config.qa_chain,
-                    retriever=retriever,
-                    messages=messages,
-                    content_callback=choice.append_content,
-                    document_records=document_records,
+            with timed_stage(choice, "Prepare indexes for search"):
+                # TODO: Move create_retriever to create_retrieval_chain
+                retriever = await loop.run_in_executor(
+                    None,
+                    create_retriever,
+                    request_context.choice,
+                    request_context.dial_config,
+                    document_records,
+                    request_config.indexing.multimodal_index,
                 )
 
-            # Answer has already been streamed to the user, so we don't need to do anything here.
-            for i, reference_item in enumerate(reference_items):
-                if attachment := doc_to_attach(
-                    reference_item, document_records, index=(i + 1)
-                ):
-                    choice.add_attachment(**attachment)
+                query_chain = create_get_query_chain(
+                    request_context, request_config.qa_chain.query_chain
+                )
+
+                retrieval_chain = await create_retrieval_chain(
+                    query_chain=query_chain,
+                    retriever=retriever,
+                )
+
+            with profiler_if_enabled(choice, request_config.use_profiler):
+                chain_input = {
+                    "chat_history": transform_history(messages),
+                    "chat_chain_config": request_config.qa_chain.chat_chain,
+                    "doc_records": document_records,
+                }
+
+                await _run_rag(
+                    request_context,
+                    choice,
+                    request_config,
+                    retrieval_chain,
+                    chain_input,
+                )
 
     async def configuration(self, request):
         return RequestConfig.model_json_schema()

--- a/aidial_rag/qa_chain.py
+++ b/aidial_rag/qa_chain.py
@@ -83,8 +83,7 @@ def create_docs_message(
 
         if chunk.page_image_index is not None:
             image = retrieval_results.images[chunk.page_image_index]
-            if image:
-                docs_message.append(image_element(image.data))
+            docs_message.append(image_element(image.data))
 
         docs_message.append(text_element("</doc>\n"))
     docs_message.append(text_element("</context>"))

--- a/aidial_rag/qa_chain.py
+++ b/aidial_rag/qa_chain.py
@@ -11,17 +11,16 @@ from langchain.prompts.chat import (
 from langchain.schema import Document
 from langchain.schema.output_parser import StrOutputParser
 from langchain_core.messages import (
+    BaseMessage,
     HumanMessage,
     merge_content,
 )
 from langchain_core.runnables import Runnable, chain
 
-from aidial_rag.app_config import RequestConfig
-from aidial_rag.document_record import DocumentRecord
-from aidial_rag.index_record import ChunkMetadata
 from aidial_rag.llm import create_llm
 from aidial_rag.qa_chain_config import ChatChainConfig
 from aidial_rag.request_context import RequestContext
+from aidial_rag.retrieval_api import RetrievalResults
 
 logger = logging.getLogger(__name__)
 
@@ -49,21 +48,24 @@ SINGLE_QUERY_TEMPLATE = HumanMessagePromptTemplate.from_template("{query}")
 
 REF_PATTERN = re.compile(r"<\[(\d+)\]>")
 
-INCLUDED_ATTRIBUTES = ["source", "page_number", "title"]
+INCLUDED_ATTRIBUTES = ["page_number", "source", "title"]
 
 
-def format_attributes(i, metadata: dict) -> str:
+def format_attributes(i, metadata: Dict[str, int | str]) -> str:
     attributes = [("id", i)] + [
-        (k, v) for k, v in metadata.items() if k in INCLUDED_ATTRIBUTES
+        (k, metadata[k]) for k in INCLUDED_ATTRIBUTES if k in metadata
     ]
     return " ".join(f"{k}='{v}'" for k, v in attributes)
 
 
-def text_element(text: str) -> dict:
+MessageElement = Dict[str, str | Dict[str, str]]
+
+
+def text_element(text: str) -> MessageElement:
     return {"type": "text", "text": text}
 
 
-def image_element(image: str) -> dict:
+def image_element(image: str) -> MessageElement:
     return {
         "type": "image_url",
         "image_url": {"url": f"data:image/png;base64,{image}"},
@@ -71,27 +73,18 @@ def image_element(image: str) -> dict:
 
 
 def create_docs_message(
-    doc_records, chunks_metadatas, image_by_page
-) -> List[Dict[str, dict]]:
-    attached_images = set()
-    docs_message = []
+    retrieval_results: RetrievalResults,
+) -> List[MessageElement]:
+    docs_message: List[MessageElement] = []
     docs_message.append(text_element("<context>"))
-    for i, chunk_metadata in enumerate(chunks_metadatas, start=1):
-        doc_record = doc_records[chunk_metadata["doc_id"]]
-        chunk = doc_record.chunks[chunk_metadata["chunk_id"]]
-
-        attributes = format_attributes(i, chunk.metadata)
+    for i, chunk in enumerate(retrieval_results.chunks, start=1):
+        attributes = format_attributes(i, chunk.model_dump(exclude_none=True))
         docs_message.append(text_element(f"<doc {attributes}>\n{chunk.text}\n"))
 
-        image_key = (
-            chunk_metadata["doc_id"],
-            chunk.metadata.get("page_number"),
-        )
-        if image_key not in attached_images and (
-            image := image_by_page.get(image_key)
-        ):
-            docs_message.append(image_element(image))
-            attached_images.add(image_key)
+        if chunk.page_image_index is not None:
+            image = retrieval_results.images[chunk.page_image_index]
+            if image:
+                docs_message.append(image_element(image.data))
 
         docs_message.append(text_element("</doc>\n"))
     docs_message.append(text_element("</context>"))
@@ -103,24 +96,15 @@ def create_docs_message(
 # and we may get several chains running in parallel.
 # Some functions used in chain may be not thread-safe, like extract_pages_gen
 @chain
-async def create_chat_prompt(input: dict):
+async def create_chat_prompt(input: Dict[str, Any]) -> List[BaseMessage]:
     config: ChatChainConfig = input["chat_chain_config"]
 
     system_prompt_template = (
         config.system_prompt_template_override or DEFAULT_SYSTEM_TEMPLATE
     )
 
-    doc_records: List[DocumentRecord] = input.get("doc_records", [])
-    index_items: List[Document] = input.get("found_items", [])
-    image_by_page: Dict[tuple, str] = input.get("image_by_page", {})
-
-    chunks_metadatas = [
-        ChunkMetadata(**index_item.metadata) for index_item in index_items
-    ]
-
-    docs_message = create_docs_message(
-        doc_records, chunks_metadatas, image_by_page
-    )
+    retrieval_results = input["retrieval_results"]
+    docs_message = create_docs_message(retrieval_results)
 
     template = ChatPromptTemplate.from_messages(
         [
@@ -205,16 +189,13 @@ async def get_reference_documents(chain_input, chain) -> AsyncIterator:  # noqa:
 
 async def generate_answer(
     request_context: RequestContext,
-    request_config: RequestConfig,
-    retrieval_chain: Runnable[Dict[str, Any], Dict],
+    retrieval_chain: Runnable[Dict[str, Any], Dict[str, Any]],
     chain_input: Dict[str, Any],
     content_callback: Callable[[str], None],
 ) -> List[Document]:
-    qa_chain_config = request_config.qa_chain
+    chat_chain_config = chain_input["chat_chain_config"]
 
-    llm = create_llm(
-        request_context.dial_config, qa_chain_config.chat_chain.llm
-    )
+    llm = create_llm(request_context.dial_config, chat_chain_config.llm)
     qa_chain = retrieval_chain.assign(
         answer=create_chat_prompt | llm | StrOutputParser()
     ).pick(["found_items", "answer"])

--- a/aidial_rag/retrieval_api.py
+++ b/aidial_rag/retrieval_api.py
@@ -1,0 +1,63 @@
+from typing import ClassVar, List
+
+from pydantic import BaseModel, Field
+
+
+class RetrievalResults(BaseModel):
+    """Results of the Dial RAG retrieval process."""
+
+    CONTENT_TYPE: ClassVar[str] = (
+        "application/vnd.aidial.rag.retrieval-results+json"
+    )
+
+    class Chunk(BaseModel):
+        """Chunk of the document retrieved by the retriever."""
+
+        doc_id: int = Field(
+            description="Index of the attached document in the request, starting from 0."
+        )
+        chunk_id: int = Field(
+            description="Index of the chunk in the document, starting from 0."
+        )
+        source: str = Field(
+            description="URL to the document attachment (relative URL to the Dial storage, or full url for an external document), could have an url fragments like #page=3."
+        )
+        source_display_name: str | None = Field(
+            default=None,
+            description="Human-readable name of the document (the same that Dial RAG displays in the stages).",
+        )
+        text: str | None = Field(
+            default=None,
+            description="Text of the chunk, may be empty, for example, for an image.",
+        )
+        page_number: int | None = Field(
+            default=None,
+            description="The number of the page in the document, the chunk belongs to, if applicable. "
+            "Starting from 1, i.e. the same as in the page fragment of the URL.",
+        )
+        page_image: int | None = Field(
+            default=None,
+            description="Index of the image of the document page, the chunk belongs to, in the `images` list."
+            "Starting from 0. If the chunk is an image, this field is set to the index of the image in the `images` list.",
+        )
+
+    class Image(BaseModel):
+        """Image related to the retrieved chunk."""
+
+        data: str = Field(
+            description="Base64 encoded image data in image/png format."
+        )
+        mime_type: str = Field(
+            default="image/png",
+            description="MIME type of the image. Only image/png is supported for now.",
+        )
+
+    chunks: List[Chunk] = Field(
+        default_factory=list,
+        description="List of chunks found by retriever in the order of their relevance.",
+    )
+
+    images: List[Image] = Field(
+        default_factory=list,
+        description="List of images related to the chunks.",
+    )

--- a/aidial_rag/retrieval_api.py
+++ b/aidial_rag/retrieval_api.py
@@ -35,13 +35,12 @@ class RetrievalResults(BaseModel):
         )
         page_number: int | None = Field(
             default=None,
-            description="The the page number in the document, the chunk belongs to, if applicable. "
-            "Starting from 1, i.e. the same as in the page fragment of the URL.",
+            description="The the page number in the document, the chunk belongs to, if applicable, "
+            "1-based (i.e. the same as in the page fragment of the URL).",
         )
         page_image_index: int | None = Field(
             default=None,
-            description="Index of the image of the document page, the chunk belongs to, in the `images` list."
-            "Starting from 0.",
+            description="Index of the image of the document page, the chunk belongs to, in the `images` list, 0-based.",
         )
 
     class Image(BaseModel):

--- a/aidial_rag/retrieval_api.py
+++ b/aidial_rag/retrieval_api.py
@@ -14,17 +14,20 @@ class RetrievalResults(BaseModel):
         """Chunk of the document retrieved by the retriever."""
 
         doc_id: int = Field(
-            description="Index of the attached document in the request, starting from 0."
+            description="Index of the attached document in the request, 0-based."
         )
         chunk_id: int = Field(
-            description="Index of the chunk in the document, starting from 0."
+            description="Index of the chunk in the document, 0-based."
         )
         source: str = Field(
-            description="URL to the document attachment (relative URL to the Dial storage, or full url for an external document), could have an url fragments like #page=3."
+            description="URL to the source of the chunk. The source could be a document "
+            "or some part of the document, like a page or a section. The URL could have "
+            "a fragment to indicate a specific part of the document, like a page number "
+            "(for example, #page=3).",
         )
         source_display_name: str | None = Field(
             default=None,
-            description="Human-readable name of the document (the same that Dial RAG displays in the stages).",
+            description="Human-readable name of the source (the same that Dial RAG displays in the stages).",
         )
         text: str | None = Field(
             default=None,
@@ -32,13 +35,13 @@ class RetrievalResults(BaseModel):
         )
         page_number: int | None = Field(
             default=None,
-            description="The number of the page in the document, the chunk belongs to, if applicable. "
+            description="The the page number in the document, the chunk belongs to, if applicable. "
             "Starting from 1, i.e. the same as in the page fragment of the URL.",
         )
-        page_image: int | None = Field(
+        page_image_index: int | None = Field(
             default=None,
             description="Index of the image of the document page, the chunk belongs to, in the `images` list."
-            "Starting from 0. If the chunk is an image, this field is set to the index of the image in the `images` list.",
+            "Starting from 0.",
         )
 
     class Image(BaseModel):


### PR DESCRIPTION
### Description of changes

- move retrieval to a separate chain to use separately in the future
- introduce RetrievalResults class which passes the results between retrieval and generation and will be used in the Retrieval Api in the future

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
