### PR TITLE
feat: allow to set index_url outside of index_storage

### DIFF
--- a/aidial_rag/dial_api_client.py
+++ b/aidial_rag/dial_api_client.py
@@ -1,0 +1,63 @@
+import io
+
+import aiohttp
+
+from aidial_rag.request_context import RequestContext
+
+
+async def _get_bucket_id(dial_base_url, headers: dict) -> str:
+    relative_url = (
+        "bucket"  # /v1/ is already included in the base url for the Dial API
+    )
+    async with aiohttp.ClientSession(base_url=dial_base_url) as session:
+        async with session.get(relative_url, headers=headers) as response:
+            response.raise_for_status()
+            data = await response.json()
+            return data["bucket"]
+
+
+def _to_form_data(key: str, data: bytes, content_type: str) -> aiohttp.FormData:
+    form_data = aiohttp.FormData()
+    form_data.add_field(
+        "file", io.BytesIO(data), filename=key, content_type=content_type
+    )
+    return form_data
+
+
+class DialApiClient:
+    def __init__(self, dial_api_base_url: str, headers: dict, bucket_id: str):
+        self.bucket_id = bucket_id
+
+        self._dial_api_base_url = dial_api_base_url
+        self._headers = headers
+
+    async def get_file(self, relative_url: str) -> bytes | None:
+        async with aiohttp.ClientSession(
+            base_url=self._dial_api_base_url
+        ) as session:
+            async with session.get(
+                relative_url, headers=self._headers
+            ) as response:
+                response.raise_for_status()
+                return await response.read()
+
+    async def put_file(
+        self, relative_url: str, data: bytes, content_type: str
+    ) -> dict:
+        async with aiohttp.ClientSession(
+            base_url=self._dial_api_base_url
+        ) as session:
+            form_data = _to_form_data(relative_url, data, content_type)
+            async with session.put(
+                relative_url, data=form_data, headers=self._headers
+            ) as response:
+                response.raise_for_status()
+                return await response.json()
+
+
+async def create_dial_api_client(
+    request_context: RequestContext,
+) -> DialApiClient:
+    headers = request_context.get_api_key_headers()
+    bucket_id = await _get_bucket_id(request_context.dial_base_url, headers)
+    return DialApiClient(request_context.dial_base_url, headers, bucket_id)

--- a/aidial_rag/documents.py
+++ b/aidial_rag/documents.py
@@ -245,8 +245,7 @@ async def load_document(
         # aidial-sdk does not allow to do stage.close(Status.FAILED) inside with-statement
         try:
             with timed_stage(
-                choice,
-                f"Load indexes for '{attachment_link.display_name}'",
+                choice, f"Load indexes for '{attachment_link.display_name}'"
             ) as load_stage:
                 doc_record = await index_storage.load(task, index_settings)
                 if doc_record is None:
@@ -257,8 +256,7 @@ async def load_document(
 
         if doc_record is None:
             with timed_stage(
-                choice,
-                f"Processing document '{attachment_link.display_name}'",
+                choice, f"Processing document '{attachment_link.display_name}'"
             ) as doc_stage:
                 io_stream = doc_stage.content_stream
                 try:
@@ -277,8 +275,7 @@ async def load_document(
                 print_chunks_stats(io_stream, doc_record.chunks)
 
             with timed_stage(
-                choice,
-                f"Store indexes for '{attachment_link.display_name}'",
+                choice, f"Store indexes for '{attachment_link.display_name}'"
             ):
                 await index_storage.store(task, doc_record)
 

--- a/aidial_rag/index_storage.py
+++ b/aidial_rag/index_storage.py
@@ -115,19 +115,19 @@ class CachedStorage(IndexStorageBackend):
         self._storage = storage
         self._cache = LRUCacheStorage(capacity)
 
-    async def load(self, url: str, *args, **kwargs) -> bytes | None:
-        data = await self._cache.load(url, *args, **kwargs)
+    async def load(self, url: str) -> bytes | None:
+        data = await self._cache.load(url)
         if data is not None:
             return data
 
-        data = await self._storage.load(url, *args, **kwargs)
+        data = await self._storage.load(url)
         if data is not None:
-            await self._cache.store(url, data, *args, **kwargs)
+            await self._cache.store(url, data)
         return data
 
-    async def store(self, url, data: bytes, *args, **kwargs) -> dict:
-        await self._cache.store(url, data, *args, **kwargs)
-        return await self._storage.store(url, data, *args, **kwargs)
+    async def store(self, url, data: bytes) -> dict:
+        await self._cache.store(url, data)
+        return await self._storage.store(url, data)
 
 
 class IndexStorage:

--- a/aidial_rag/index_storage.py
+++ b/aidial_rag/index_storage.py
@@ -10,12 +10,15 @@ from pydantic import ByteSize, Field
 
 from aidial_rag.attachment_link import AttachmentLink
 from aidial_rag.base_config import BaseConfig
+from aidial_rag.dial_api_client import DialApiClient
 from aidial_rag.document_record import (
     FORMAT_VERSION,
     DocumentRecord,
     IndexSettings,
 )
-from aidial_rag.request_context import RequestContext
+from aidial_rag.indexing_task import IndexingTask
+
+logger = logging.getLogger(__name__)
 
 
 class IndexStorageConfig(BaseConfig):
@@ -45,21 +48,31 @@ SERIALIZATION_CONFIG = {"protocol": "pickle", "compress": "gzip"}
 INDEX_MIME_TYPE = "application/x.aidial-rag-index.v0"
 
 
-def link_to_key(attachment_link: AttachmentLink) -> str:
-    return hashlib.sha256(attachment_link.dial_link.encode()).hexdigest()
+# Number of characters in each directory part for index file paths
+# This is treated as a part of an algorithm, not a configuration parameter,
+# because if changed, the old index files will not be found.
+INDEX_PATH_PART_SIZE = 8
+
+
+def link_to_index_url(attachment_link: AttachmentLink, bucket_id: str) -> str:
+    key = hashlib.sha256(attachment_link.dial_link.encode()).hexdigest()
+
+    # split the key into parts to avoid too many files in one directory
+    dir_path = "/".join(
+        key[i : i + INDEX_PATH_PART_SIZE]
+        for i in range(0, len(key), INDEX_PATH_PART_SIZE)
+    )
+
+    return f"files/{bucket_id}/dial-rag-index/{dir_path}/index.bin"
 
 
 class IndexStorageBackend(ABC):
     @abstractmethod
-    async def load(
-        self, key: str, request_context: RequestContext
-    ) -> bytes | None:
+    async def load(self, url: str, *args, **kwargs) -> bytes | None:
         pass
 
     @abstractmethod
-    async def store(
-        self, key: str, data: bytes, request_context: RequestContext
-    ) -> dict:
+    async def store(self, url: str, data: bytes, *args, **kwargs) -> dict:
         pass
 
 
@@ -67,15 +80,11 @@ class LRUCacheStorage(IndexStorageBackend):
     def __init__(self, capacity: int = DEFAULT_IN_MEMORY_CACHE_CAPACITY):
         self._cache = LRUCache(maxsize=capacity, getsizeof=len)
 
-    async def load(
-        self, key: str, request_context: RequestContext
-    ) -> bytes | None:
-        return cast(bytes | None, self._cache.get(key))
+    async def load(self, url: str, *args, **kwargs) -> bytes | None:
+        return cast(bytes | None, self._cache.get(url))
 
-    async def store(
-        self, key, data: bytes, request_context: RequestContext
-    ) -> dict:
-        self._cache[key] = data
+    async def store(self, url, data: bytes, *args, **kwargs) -> dict:
+        self._cache[url] = data
         return {}
 
 
@@ -86,28 +95,7 @@ class DialFileStorage(IndexStorageBackend):
 
     def __init__(self, dial_url: str):
         self._dial_url = dial_url
-
-    async def get_bucket_id(self, headers: dict) -> str:
-        # Cannot initialize bucket_id in __init__ because we need api-key headers to access the bucket
-        bucket_url = f"{self._dial_url}/v1/bucket"
-        async with aiohttp.ClientSession() as session:
-            async with session.get(bucket_url, headers=headers) as response:
-                response.raise_for_status()
-                data = await response.json()
-                return data["bucket"]
-
-    async def index_url(
-        self, key: str, headers: dict, dir_part_size: int = 8
-    ) -> str:
-        bucket_id = await self.get_bucket_id(headers)
-
-        # split the key into parts to avoid too many files in one directory
-        dir_path = "/".join(
-            key[i : i + dir_part_size]
-            for i in range(0, len(key), dir_part_size)
-        )
-
-        return f"{self._dial_url}/v1/files/{bucket_id}/dial-rag-index/{dir_path}/index.bin"
+        self._dial_base_url = f"{dial_url}/v1/"
 
     def to_form_data(self, key: str, data: bytes) -> aiohttp.FormData:
         form_data = aiohttp.FormData()
@@ -117,31 +105,18 @@ class DialFileStorage(IndexStorageBackend):
         return form_data
 
     async def load(
-        self, key: str, request_context: RequestContext
+        self, url: str, dial_api_client: DialApiClient
     ) -> bytes | None:
-        async with aiohttp.ClientSession() as session:
-            headers = request_context.get_api_key_headers()
-            url = await self.index_url(key, headers)
-            async with session.get(url, headers=headers) as response:
-                if not response.ok:
-                    logging.warning(
-                        f"Failed to load index from {url}: {response.status}, {response.reason}"
-                    )
-                    return None
-                return await response.read()
+        try:
+            return await dial_api_client.get_file(url)
+        except aiohttp.ClientError as e:
+            logger.warning(f"Failed to load index from {url}: {e}")
+            return None
 
     async def store(
-        self, key, data: bytes, request_context: RequestContext
+        self, url, data: bytes, dial_api_client: DialApiClient
     ) -> dict:
-        async with aiohttp.ClientSession() as session:
-            headers = request_context.get_api_key_headers()
-            url = await self.index_url(key, headers)
-            form_data = self.to_form_data(key, data)
-            async with session.put(
-                url, data=form_data, headers=headers
-            ) as response:
-                response.raise_for_status()
-                return await response.json()
+        return await dial_api_client.put_file(url, data, INDEX_MIME_TYPE)
 
 
 class CachedStorage(IndexStorageBackend):
@@ -153,23 +128,19 @@ class CachedStorage(IndexStorageBackend):
         self._storage = storage
         self._cache = LRUCacheStorage(capacity)
 
-    async def load(
-        self, key: str, request_context: RequestContext
-    ) -> bytes | None:
-        data = await self._cache.load(key, request_context)
+    async def load(self, url: str, *args, **kwargs) -> bytes | None:
+        data = await self._cache.load(url, *args, **kwargs)
         if data is not None:
             return data
 
-        data = await self._storage.load(key, request_context)
+        data = await self._storage.load(url, *args, **kwargs)
         if data is not None:
-            await self._cache.store(key, data, request_context)
+            await self._cache.store(url, data, *args, **kwargs)
         return data
 
-    async def store(
-        self, key, data: bytes, request_context: RequestContext
-    ) -> dict:
-        await self._cache.store(key, data, request_context)
-        return await self._storage.store(key, data, request_context)
+    async def store(self, url, data: bytes, *args, **kwargs) -> dict:
+        await self._cache.store(url, data, *args, **kwargs)
+        return await self._storage.store(url, data, *args, **kwargs)
 
 
 class IndexStorage:
@@ -192,12 +163,12 @@ class IndexStorage:
 
     async def load(
         self,
-        attachment_link: AttachmentLink,
+        task: IndexingTask,
         index_settings: IndexSettings,
-        request_context: RequestContext,
+        dial_api_client: DialApiClient,
     ) -> DocumentRecord | None:
         doc_record_bytes = await self._storage.load(
-            link_to_key(attachment_link), request_context
+            task.index_url, dial_api_client=dial_api_client
         )
         if doc_record_bytes is None:
             return None
@@ -206,29 +177,32 @@ class IndexStorage:
                 doc_record_bytes, **SERIALIZATION_CONFIG
             )
             if doc_record.format_version != FORMAT_VERSION:
-                logging.warning(
-                    f"Index format version mismatch for {attachment_link}: {doc_record.format_version}"
+                logger.warning(
+                    f"Index format version mismatch for {task.attachment_link}: {doc_record.format_version}"
                 )
                 return None
             if doc_record.index_settings != index_settings:
-                logging.warning(
-                    f"Index settings mismatch for {attachment_link}: {doc_record.index_settings}"
+                logger.warning(
+                    f"Index settings mismatch for {task.attachment_link}: {doc_record.index_settings}"
                 )
                 return None
             return doc_record
         except Exception as e:
-            logging.warning(
-                f"Failed to deserialize index for {attachment_link}: {e}"
+            logger.warning(
+                f"Failed to deserialize index for {task.attachment_link}: {e}"
             )
             return None
 
     async def store(
         self,
-        attachment_link: AttachmentLink,
+        task: IndexingTask,
         doc_record: DocumentRecord,
-        request_context: RequestContext,
+        dial_api_client: DialApiClient,
     ) -> dict:
         doc_record_bytes = doc_record.to_bytes(**SERIALIZATION_CONFIG)
-        key = link_to_key(attachment_link)
-        logging.debug(f"Stored document {attachment_link} with key: {key}")
-        return await self._storage.store(key, doc_record_bytes, request_context)
+        logger.debug(
+            f"Stored document {task.attachment_link} index with url: {task.index_url}"
+        )
+        return await self._storage.store(
+            task.index_url, doc_record_bytes, dial_api_client=dial_api_client
+        )

--- a/aidial_rag/indexing_task.py
+++ b/aidial_rag/indexing_task.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel, ConfigDict
+
+from aidial_rag.attachment_link import AttachmentLink
+
+
+class IndexingTask(BaseModel):
+    """Task for loading a document and indexing it."""
+
+    attachment_link: AttachmentLink
+    index_url: str
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/tests/utils/cache_middleware.py
+++ b/tests/utils/cache_middleware.py
@@ -269,6 +269,10 @@ class CacheMiddlewareApp(FastAPI):
                 "dayTokenStats": {"total": 1000000, "used": 0},
             }
 
+        @self.get("/v1/bucket")
+        async def get_bucket_info():
+            return {"bucket": "test_bucket"}
+
         @self.get("/health")
         async def health_check():
             return {"status": "ok"}


### PR DESCRIPTION
### Description of changes

- index_url is now set outside of the index_storage to allow to set desired index store location in the request parameters in the future
- IndexingTask class was added to specify which index_url correcponds to which attachment_link
- Dial requests were moved from index_storage to DialApiClient to be able to get the bucket_id from Dial outside of the index_storage. Other Dial API requests will be moved to the DialApiClient  in the future

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
