### PR TITLE
fix: fix hanging tests

### DIFF
--- a/aidial_rag/document_loaders.py
+++ b/aidial_rag/document_loaders.py
@@ -30,7 +30,8 @@ from aidial_rag.request_context import RequestContext
 from aidial_rag.resources.cpu_pools import run_in_indexing_cpu_pool
 from aidial_rag.utils import format_size, get_bytes_length, timed_block
 
-# Create a stub for UnstructuredClient to avoid creating/destroying it in every request.
+# Create a stub for UnstructuredClient as a global object to avoid creating/destroying
+# it in every request.
 # We do not use unstructured api, but the langchain_unstructured will create the client
 # even for partition_via_api=False.
 # The UnstructuredClient registers close_clients as weakref.finalize which could be called


### PR DESCRIPTION
### Description of changes

Fixes hanging tests for the application.
There is an issue that the tests for the application (with fastapi.testclient) may hang. For example, this run: https://github.com/epam/ai-dial-rag/actions/runs/16473749024/job/46569649203?pr=34

The reason is following:
- We use `langchain_unstructured.UnstructuredLoader` to parse the document using the open source unstructured library.
- `partition_via_api` is `False` by default - we do not use unstructured API, but `langchain_unstructured.UnstructuredLoader` creates  `UnstructuredClient` anyway: https://github.com/langchain-ai/langchain-unstructured/blob/main/libs/unstructured/langchain_unstructured/document_loaders.py#L138
- The `UnstructuredClient` registers `close_clients` as `weakref.finalize` which could be called by garbage collector at any time: https://github.com/Unstructured-IO/unstructured-python-client/blob/9576035a9c9f7eef97da90db177bf057e5f62471/src/unstructured_client/sdk.py#L107
- The `close_clients` uses `ThreadPoolExecutor.submit` to schedule the `aclose` for the client  https://github.com/Unstructured-IO/unstructured-python-client/blob/9576035a9c9f7eef97da90db177bf057e5f62471/src/unstructured_client/httpclient.py#L129
- If `close_clients` happen to be called during `ThreadPoolExecutor.submit` itself, it could block the thread of the lock in ThreadPoolExecutor and cause a deadlock. See screenshot:
<img width="3840" height="2064" alt="Screenshot 2025-07-28 212315" src="https://github.com/user-attachments/assets/dfa5c6a9-e6ad-4d2b-92df-446e2585ab9e" />

This PR changes `document_loaders.py` to avoid creating/destroying `UnstructuredClient` to avoid this issue.

Note: the `close_clients` code has been changed several times since the version we use and is different now: https://github.com/Unstructured-IO/unstructured-python-client/blob/main/src/unstructured_client/httpclient.py#L120 . But, I think, it would be better to avoid the issue at all, since we do not use the `UnstructuredClient` anyway.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
