### PR TITLE
fix: fix source and page in retrieval response

### DIFF
--- a/aidial_rag/qa_chain.py
+++ b/aidial_rag/qa_chain.py
@@ -48,13 +48,18 @@ SINGLE_QUERY_TEMPLATE = HumanMessagePromptTemplate.from_template("{query}")
 
 REF_PATTERN = re.compile(r"<\[(\d+)\]>")
 
-INCLUDED_ATTRIBUTES = ["page_number", "source", "title"]
 
+def format_attributes(
+    id: int,
+    page_number: int | None,
+    source_url: str | None,
+) -> str:
+    attributes = [("id", str(id))]
+    if page_number is not None:
+        attributes.append(("page_number", str(page_number)))
+    if source_url:
+        attributes.append(("source", source_url))
 
-def format_attributes(i, metadata: Dict[str, int | str]) -> str:
-    attributes = [("id", i)] + [
-        (k, metadata[k]) for k in INCLUDED_ATTRIBUTES if k in metadata
-    ]
     return " ".join(f"{k}='{v}'" for k, v in attributes)
 
 
@@ -78,11 +83,15 @@ def create_docs_message(
     docs_message: List[MessageElement] = []
     docs_message.append(text_element("<context>"))
     for i, chunk in enumerate(retrieval_results.chunks, start=1):
-        attributes = format_attributes(i, chunk.model_dump(exclude_none=True))
+        attributes = format_attributes(
+            id=i,
+            page_number=chunk.page.number if chunk.page else None,
+            source_url=chunk.source.url if chunk.source else None,
+        )
         docs_message.append(text_element(f"<doc {attributes}>\n{chunk.text}\n"))
 
-        if chunk.page_image_index is not None:
-            image = retrieval_results.images[chunk.page_image_index]
+        if chunk.page is not None and chunk.page.image_index is not None:
+            image = retrieval_results.images[chunk.page.image_index]
             docs_message.append(image_element(image.data))
 
         docs_message.append(text_element("</doc>\n"))

--- a/aidial_rag/qa_chain.py
+++ b/aidial_rag/qa_chain.py
@@ -86,7 +86,7 @@ def create_docs_message(
         attributes = format_attributes(
             id=i,
             page_number=chunk.page.number if chunk.page else None,
-            source_url=chunk.source.url if chunk.source else None,
+            source_url=chunk.source.url,
         )
         docs_message.append(text_element(f"<doc {attributes}>\n{chunk.text}\n"))
 

--- a/aidial_rag/retrieval_api.py
+++ b/aidial_rag/retrieval_api.py
@@ -3,55 +3,75 @@ from typing import ClassVar, List
 from pydantic import BaseModel, Field
 
 
+class Source(BaseModel):
+    """Source of the chunk, intended to show the user where the chunk comes from.
+    The source could be a document or some part of the document, like a page or a section.
+    """
+
+    url: str = Field(
+        description="URL for the source. The URL could have a fragment to indicate "
+        "a specific part of the document, like a page number (for example, #page=3)."
+    )
+    display_name: str | None = Field(
+        default=None,
+        description="Human-readable name of the source (the same that Dial RAG displays in the stages).",
+    )
+
+
+class Page(BaseModel):
+    """Page of the document."""
+
+    number: int = Field(
+        description="Page number in the document, 1-based (i.e. the same as in the page fragment of the URL)."
+    )
+    image_index: int | None = Field(
+        default=None,
+        description="Index of the image of the document page in the `images` list, 0-based.",
+    )
+
+
+class Image(BaseModel):
+    """Image related to the retrieved chunk."""
+
+    data: str = Field(
+        description="Base64 encoded image data in image/png format."
+    )
+    mime_type: str = Field(
+        default="image/png",
+        description="MIME type of the image. Only image/png is supported for now.",
+    )
+
+
+class Chunk(BaseModel):
+    """Chunk of the document retrieved by the retriever."""
+
+    attachment_url: str = Field(
+        description="URL of the attached document, the chunk belongs to. "
+        "Exactly matches with the `attachment.url` field in the request.",
+    )
+
+    source: Source = Field(
+        description="Source this chunk belongs to. The source could be a document "
+        "or some part of the document, like a page or a section."
+    )
+
+    text: str | None = Field(
+        default=None,
+        description="Text of the chunk, may be empty, for example, for an image.",
+    )
+
+    page: Page | None = Field(
+        default=None,
+        description="Page of the document, the chunk belongs to, if applicable.",
+    )
+
+
 class RetrievalResults(BaseModel):
     """Results of the Dial RAG retrieval process."""
 
     CONTENT_TYPE: ClassVar[str] = (
         "application/vnd.aidial.rag.retrieval-results+json"
     )
-
-    class Chunk(BaseModel):
-        """Chunk of the document retrieved by the retriever."""
-
-        attachment_url: str = Field(
-            description="URL of the attached document, the chunk belongs to. "
-            "Exactly matches with the `attachment.url` field in the request.",
-        )
-
-        source: str = Field(
-            description="URL to the source of the chunk. The source could be a document "
-            "or some part of the document, like a page or a section. The URL could have "
-            "a fragment to indicate a specific part of the document, like a page number "
-            "(for example, #page=3).",
-        )
-        source_display_name: str | None = Field(
-            default=None,
-            description="Human-readable name of the source (the same that Dial RAG displays in the stages).",
-        )
-        text: str | None = Field(
-            default=None,
-            description="Text of the chunk, may be empty, for example, for an image.",
-        )
-        page_number: int | None = Field(
-            default=None,
-            description="The the page number in the document, the chunk belongs to, if applicable, "
-            "1-based (i.e. the same as in the page fragment of the URL).",
-        )
-        page_image_index: int | None = Field(
-            default=None,
-            description="Index of the image of the document page, the chunk belongs to, in the `images` list, 0-based.",
-        )
-
-    class Image(BaseModel):
-        """Image related to the retrieved chunk."""
-
-        data: str = Field(
-            description="Base64 encoded image data in image/png format."
-        )
-        mime_type: str = Field(
-            default="image/png",
-            description="MIME type of the image. Only image/png is supported for now.",
-        )
 
     chunks: List[Chunk] = Field(
         default_factory=list,

--- a/aidial_rag/retrievers/all_documents_retriever.py
+++ b/aidial_rag/retrievers/all_documents_retriever.py
@@ -19,7 +19,13 @@ class AllDocumentsRetriever(BaseRetriever):
         # So we have to include the size of the metadata in the size estimation
         return (
             len(chunk.text)
-            + len(format_attributes(i, chunk.metadata))
+            + len(
+                format_attributes(
+                    id=i,
+                    page_number=chunk.metadata.get("page_number"),
+                    source_url=chunk.metadata.get("source"),
+                )
+            )
             + AllDocumentsRetriever._CHUNK_PROMPT_OVERHEAD
         )
 

--- a/tests/test_app_retrieval.py
+++ b/tests/test_app_retrieval.py
@@ -84,7 +84,10 @@ async def test_retrieval_request(attachments):
     )
 
     for chunk in retrieval_results.chunks[1:]:
-        assert chunk.attachment_url == "files/6iTkeGUs2CvUehhYLmMYXB/alps_wiki.html"
+        assert (
+            chunk.attachment_url
+            == "files/6iTkeGUs2CvUehhYLmMYXB/alps_wiki.html"
+        )
         assert chunk.source == Source(
             url="files/6iTkeGUs2CvUehhYLmMYXB/alps_wiki.html",
             display_name="alps_wiki.html",

--- a/tests/test_app_retrieval.py
+++ b/tests/test_app_retrieval.py
@@ -83,16 +83,14 @@ async def test_retrieval_request(attachments):
         r"^iVBORw0KGgoAAAA.*CYII=$", retrieval_results.images[0].data
     )
 
-    assert all(
-        chunk.attachment_url == "files/6iTkeGUs2CvUehhYLmMYXB/alps_wiki.html"
-        and chunk.source
-        == Source(
+    for chunk in retrieval_results.chunks[1:]:
+        assert chunk.attachment_url == "files/6iTkeGUs2CvUehhYLmMYXB/alps_wiki.html"
+        assert chunk.source == Source(
             url="files/6iTkeGUs2CvUehhYLmMYXB/alps_wiki.html",
             display_name="alps_wiki.html",
         )
-        and chunk.page is None
-        for chunk in retrieval_results.chunks[1:]
-    )
+        assert chunk.page is None
+
     assert retrieval_results.chunks[1].text is not None
     assert retrieval_results.chunks[1].text.startswith(
         "Techniques and tools Quantitative Cartography"

--- a/tests/test_app_retrieval.py
+++ b/tests/test_app_retrieval.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 
 from aidial_rag.app import create_app
 from aidial_rag.app_config import AppConfig
-from aidial_rag.retrieval_api import RetrievalResults
+from aidial_rag.retrieval_api import Page, RetrievalResults, Source
 from tests.utils.config_override import (
     description_index_retries_override,  # noqa: F401
 )
@@ -68,13 +68,14 @@ async def test_retrieval_request(attachments):
         == "files/6iTkeGUs2CvUehhYLmMYXB/test_image.png"
     )
     assert chunk_from_image.text == ""
-    assert (
-        chunk_from_image.source == "files/6iTkeGUs2CvUehhYLmMYXB/test_image.png"
+    assert chunk_from_image.source == Source(
+        url="files/6iTkeGUs2CvUehhYLmMYXB/test_image.png",
+        display_name="test_image.png",
     )
-    assert chunk_from_image.source_display_name == "test_image.png"
-    assert chunk_from_image.text == ""
-    assert chunk_from_image.page_number == 1
-    assert chunk_from_image.page_image_index == 0
+    assert chunk_from_image.page == Page(
+        number=1,
+        image_index=0,
+    )
 
     assert len(retrieval_results.images) == 1
     assert retrieval_results.images[0].mime_type == "image/png"
@@ -84,10 +85,12 @@ async def test_retrieval_request(attachments):
 
     assert all(
         chunk.attachment_url == "files/6iTkeGUs2CvUehhYLmMYXB/alps_wiki.html"
-        and chunk.source_display_name == "alps_wiki.html"
-        and chunk.source == "files/6iTkeGUs2CvUehhYLmMYXB/alps_wiki.html"
-        and chunk.page_number is None
-        and chunk.page_image_index is None
+        and chunk.source
+        == Source(
+            url="files/6iTkeGUs2CvUehhYLmMYXB/alps_wiki.html",
+            display_name="alps_wiki.html",
+        )
+        and chunk.page is None
         for chunk in retrieval_results.chunks[1:]
     )
     assert retrieval_results.chunks[1].text is not None


### PR DESCRIPTION
### Description of changes

Retrieval API response was changed:
- `source` and `source_display_name` is changed to `source.url` and `source.display_name` in the `source` object.
- `page_number` and `page_image_index` is changes to `page.number` and `page.image_index` in the `page` object.
- `format_attributes` in qa_chain prompt formatting is decoupled from the names of the fields in RetrievalResults Chunk.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
