### PR TITLE
fix: check index path for dial-rag bucket

### DIFF
--- a/aidial_rag/app.py
+++ b/aidial_rag/app.py
@@ -288,6 +288,7 @@ class DialRAGApplication(ChatCompletion):
                 request_context,
                 indexing_tasks,
                 index_storage,
+                dial_api_client,
                 config=request_config,
             )
 

--- a/aidial_rag/app.py
+++ b/aidial_rag/app.py
@@ -32,18 +32,14 @@ from aidial_rag.configuration_endpoint import (
     RequestType,
     get_configuration,
 )
-from aidial_rag.dial_api_client import DialApiClient, create_dial_api_client
+from aidial_rag.dial_api_client import create_dial_api_client
 from aidial_rag.document_record import Chunk, DocumentRecord
 from aidial_rag.documents import load_documents
-from aidial_rag.errors import InvalidDocumentError
 from aidial_rag.index_record import ChunkMetadata, RetrievalType
 from aidial_rag.index_storage import (
     IndexStorageHolder,
-    link_to_index_url,
 )
 from aidial_rag.indexing_api import (
-    INDEX_MIME_TYPE,
-    INDEX_MIME_TYPES_REGEX,
     create_indexing_results_attachments,
 )
 from aidial_rag.indexing_results import (
@@ -53,7 +49,7 @@ from aidial_rag.indexing_results import (
     format_document_loading_errors,
     get_indexing_failures,
 )
-from aidial_rag.indexing_task import IndexingTask
+from aidial_rag.indexing_task import create_indexing_tasks
 from aidial_rag.qa_chain import generate_answer
 from aidial_rag.query_chain import create_get_query_chain
 from aidial_rag.repository_digest import (
@@ -124,43 +120,6 @@ def _collect_document_records(
             document_records_links.append(result.task.attachment_link)
 
     return document_records, document_records_links
-
-
-def _is_rag_index(attachment: AttachmentLink) -> bool:
-    """Check if the attachment is a RAG index."""
-
-    if attachment.type is None:
-        return False
-    if not INDEX_MIME_TYPES_REGEX.match(attachment.type):
-        return False
-    if attachment.type != INDEX_MIME_TYPE:
-        raise InvalidDocumentError(f"Unknown index type: {attachment.type}")
-    if not attachment.reference_url:
-        raise InvalidDocumentError("Index attachment must have a reference URL")
-    return True
-
-
-def create_indexing_tasks(
-    attachment_links: List[AttachmentLink],
-    dial_api_client: DialApiClient,
-) -> List[IndexingTask]:
-    index_attachments = {
-        str(attachment.reference_url): attachment.dial_link
-        for attachment in attachment_links
-        if _is_rag_index(attachment)
-    }
-
-    return [
-        IndexingTask(
-            attachment_link=link,
-            index_url=(
-                index_attachments.get(link.dial_link)
-                or link_to_index_url(link, dial_api_client.bucket_id)
-            ),
-        )
-        for link in attachment_links
-        if not _is_rag_index(link)
-    ]
 
 
 def _add_indexing_results(

--- a/aidial_rag/index_mime_type.py
+++ b/aidial_rag/index_mime_type.py
@@ -1,0 +1,10 @@
+import re
+
+INDEX_MIME_TYPE = "application/x.aidial-rag-index.v0"
+INDEX_MIME_TYPES_REGEX = re.compile(r"^application/x\.aidial-rag-index\..*$")
+
+
+assert INDEX_MIME_TYPES_REGEX.match(INDEX_MIME_TYPE), (
+    f"Invalid INDEX_MIME_TYPE: {INDEX_MIME_TYPE}. "
+    f"It should match the regex {INDEX_MIME_TYPES_REGEX.pattern}."
+)

--- a/aidial_rag/index_storage.py
+++ b/aidial_rag/index_storage.py
@@ -1,4 +1,3 @@
-import hashlib
 import logging
 from abc import ABC, abstractmethod
 from typing import cast
@@ -7,7 +6,6 @@ import aiohttp
 from cachetools import LRUCache
 from pydantic import ByteSize, Field
 
-from aidial_rag.attachment_link import AttachmentLink
 from aidial_rag.base_config import BaseConfig
 from aidial_rag.dial_api_client import DialApiClient
 from aidial_rag.document_record import (
@@ -15,7 +13,7 @@ from aidial_rag.document_record import (
     DocumentRecord,
     IndexSettings,
 )
-from aidial_rag.indexing_api import INDEX_MIME_TYPE
+from aidial_rag.index_mime_type import INDEX_MIME_TYPE
 from aidial_rag.indexing_task import IndexingTask
 
 logger = logging.getLogger(__name__)
@@ -44,24 +42,6 @@ DEFAULT_IN_MEMORY_CACHE_CAPACITY = IndexStorageConfig().in_memory_cache_capacity
 
 
 SERIALIZATION_CONFIG = {"protocol": "pickle", "compress": "gzip"}
-
-
-# Number of characters in each directory part for index file paths
-# This is treated as a part of an algorithm, not a configuration parameter,
-# because if changed, the old index files will not be found.
-INDEX_PATH_PART_SIZE = 8
-
-
-def link_to_index_url(attachment_link: AttachmentLink, bucket_id: str) -> str:
-    key = hashlib.sha256(attachment_link.dial_link.encode()).hexdigest()
-
-    # split the key into parts to avoid too many files in one directory
-    dir_path = "/".join(
-        key[i : i + INDEX_PATH_PART_SIZE]
-        for i in range(0, len(key), INDEX_PATH_PART_SIZE)
-    )
-
-    return f"files/{bucket_id}/dial-rag-index/{dir_path}/index.bin"
 
 
 class IndexStorageBackend(ABC):

--- a/aidial_rag/indexing_api.py
+++ b/aidial_rag/indexing_api.py
@@ -1,23 +1,14 @@
-import re
 from typing import ClassVar, Dict, List
 
 from aidial_sdk.chat_completion.request import Attachment
 from pydantic import BaseModel, Field
 
+from aidial_rag.index_mime_type import INDEX_MIME_TYPE
 from aidial_rag.indexing_results import (
     DocumentIndexingFailure,
     DocumentIndexingResult,
     DocumentIndexingSuccess,
     get_user_facing_error_message,
-)
-
-INDEX_MIME_TYPE = "application/x.aidial-rag-index.v0"
-
-INDEX_MIME_TYPES_REGEX = re.compile(r"^application/x\.aidial-rag-index\..*$")
-
-assert INDEX_MIME_TYPES_REGEX.match(INDEX_MIME_TYPE), (
-    f"Invalid INDEX_MIME_TYPE: {INDEX_MIME_TYPE}. "
-    f"It should match the regex {INDEX_MIME_TYPES_REGEX.pattern}."
 )
 
 

--- a/aidial_rag/indexing_task.py
+++ b/aidial_rag/indexing_task.py
@@ -1,6 +1,12 @@
+from typing import List
+
 from pydantic import BaseModel, ConfigDict
 
 from aidial_rag.attachment_link import AttachmentLink
+from aidial_rag.dial_api_client import DialApiClient
+from aidial_rag.errors import InvalidDocumentError
+from aidial_rag.index_storage import link_to_index_url
+from aidial_rag.indexing_api import INDEX_MIME_TYPE, INDEX_MIME_TYPES_REGEX
 
 
 class IndexingTask(BaseModel):
@@ -10,3 +16,40 @@ class IndexingTask(BaseModel):
     index_url: str
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+def _is_rag_index(attachment: AttachmentLink) -> bool:
+    """Check if the attachment is a RAG index."""
+
+    if attachment.type is None:
+        return False
+    if not INDEX_MIME_TYPES_REGEX.match(attachment.type):
+        return False
+    if attachment.type != INDEX_MIME_TYPE:
+        raise InvalidDocumentError(f"Unknown index type: {attachment.type}")
+    if not attachment.reference_url:
+        raise InvalidDocumentError("Index attachment must have a reference URL")
+    return True
+
+
+def create_indexing_tasks(
+    attachment_links: List[AttachmentLink],
+    dial_api_client: DialApiClient,
+) -> List[IndexingTask]:
+    index_attachments = {
+        str(attachment.reference_url): attachment.dial_link
+        for attachment in attachment_links
+        if _is_rag_index(attachment)
+    }
+
+    return [
+        IndexingTask(
+            attachment_link=link,
+            index_url=(
+                index_attachments.get(link.dial_link)
+                or link_to_index_url(link, dial_api_client.bucket_id)
+            ),
+        )
+        for link in attachment_links
+        if not _is_rag_index(link)
+    ]

--- a/tests/test_app_indexing.py
+++ b/tests/test_app_indexing.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 
 from aidial_rag.app import create_app
 from aidial_rag.app_config import AppConfig
-from aidial_rag.indexing_api import INDEX_MIME_TYPE
+from aidial_rag.index_mime_type import INDEX_MIME_TYPE
 from aidial_rag.retrieval_api import Page, RetrievalResults, Source
 from tests.utils.config_override import (
     description_index_retries_override,  # noqa: F401

--- a/tests/test_app_indexing.py
+++ b/tests/test_app_indexing.py
@@ -12,7 +12,12 @@ from tests.utils.config_override import (
     description_index_retries_override,  # noqa: F401
 )
 from tests.utils.e2e_decorator import e2e_test
-from tests.utils.response_helpers import get_stage_names
+from tests.utils.response_helpers import (
+    get_attachments,
+    get_index_attachments,
+    get_indexing_result_json,
+    get_stage_names,
+)
 
 middleware_host = "http://localhost:8081"
 
@@ -52,18 +57,12 @@ async def test_indexing_request(attachments):
     )
 
     assert indexing_response.status_code == 200
+    indexing_json = indexing_response.json()
 
-    indexing_response_attachments = indexing_response.json()["choices"][0][
-        "message"
-    ]["custom_content"]["attachments"]
-    index_attachments = [
-        attachment
-        for attachment in indexing_response_attachments
-        if attachment["type"] == INDEX_MIME_TYPE
-    ]
+    indexing_response_attachments = get_attachments(indexing_json)
+    index_attachments = get_index_attachments(indexing_response_attachments)
     assert len(index_attachments) == 2
 
-    indexing_json = json.loads(indexing_response.text)
     indexing_stage_names = get_stage_names(indexing_json)
     assert sorted(indexing_stage_names) == [
         "Access document 'alps_wiki.html'",
@@ -121,9 +120,7 @@ async def test_indexing_request(attachments):
         "Standalone question",
     ]
 
-    attachments = json_response["choices"][0]["message"]["custom_content"][
-        "attachments"
-    ]
+    attachments = get_attachments(json_response)
     assert len(attachments) == 1
     attachment = attachments[0]
     assert attachment["type"] == RetrievalResults.CONTENT_TYPE
@@ -204,28 +201,17 @@ async def test_unsupported_file(attachments):
     )
 
     assert indexing_response.status_code == 200
-    indexing_response_attachments = indexing_response.json()["choices"][0][
-        "message"
-    ]["custom_content"]["attachments"]
+    indexing_response_attachments = get_attachments(indexing_response.json())
 
     # alps_wiki.html should be indexed successfully
-    index_attachments = [
-        attachment
-        for attachment in indexing_response_attachments
-        if attachment["type"] == INDEX_MIME_TYPE
-    ]
+    index_attachments = get_index_attachments(indexing_response_attachments)
     assert len(index_attachments) == 1
     assert index_attachments[0]["reference_url"] == attachments[0]["url"]
 
-    indexing_result_attachment = next(
-        attachment
-        for attachment in indexing_response_attachments
-        if attachment["type"]
-        == "application/x.aidial-rag.indexing-response+json"
-    )
-
     # test_file.csv should have an error, since it is not supported
-    indexing_result_json = json.loads(indexing_result_attachment["data"])
+    indexing_result_json = get_indexing_result_json(
+        indexing_response_attachments
+    )
     assert indexing_result_json == {
         "indexing_result": {
             attachments[1]["url"]: {
@@ -284,13 +270,78 @@ async def test_custom_index_path(attachments):
     )
 
     assert indexing_response.status_code == 200
-    indexing_response_attachments = indexing_response.json()["choices"][0][
-        "message"
-    ]["custom_content"]["attachments"]
-    index_attachments_result = [
-        attachment
-        for attachment in indexing_response_attachments
-        if attachment["type"] == INDEX_MIME_TYPE
-    ]
+    indexing_response_attachments = get_attachments(indexing_response.json())
+    index_attachments_result = get_index_attachments(
+        indexing_response_attachments
+    )
     assert len(index_attachments_result) == 1
     assert index_attachments_result == index_attachments
+
+
+@pytest.mark.asyncio
+@e2e_test(filenames=["alps_wiki.html"])
+async def test_invalid_custom_index_path(attachments):
+    assert len(attachments) == 1
+
+    app = create_app(
+        app_config=AppConfig(
+            dial_url=middleware_host,
+        )
+    )
+    client = TestClient(app)
+
+    index_attachments = [
+        {
+            "type": INDEX_MIME_TYPE,
+            "url": "files/test_bucket/dial-rag-index/wrong_index_path/index.bin",
+            "reference_url": attachments[0]["url"],
+        }
+    ]
+
+    indexing_response = client.post(
+        "/openai/deployments/dial-rag/chat/completions",
+        headers={"Api-Key": "api-key"},
+        json={
+            "model": "dial-rag",
+            "messages": [
+                {
+                    "role": "user",
+                    "custom_content": {
+                        "attachments": attachments + index_attachments,
+                    },
+                }
+            ],
+            "custom_fields": {
+                "configuration": {
+                    "request": {
+                        "type": "indexing",
+                    }
+                }
+            },
+        },
+        timeout=60.0,
+    )
+
+    assert indexing_response.status_code == 200
+    indexing_response_attachments = get_attachments(indexing_response.json())
+    index_attachments_result = get_index_attachments(
+        indexing_response_attachments
+    )
+    assert len(index_attachments_result) == 0
+
+    indexing_result_json = get_indexing_result_json(
+        indexing_response_attachments
+    )
+    assert indexing_result_json == {
+        "indexing_result": {
+            attachments[0]["url"]: {
+                "errors": [
+                    {
+                        "message": "Index URL files/test_bucket/dial-rag-index/wrong_index_path/index.bin "
+                        "does not match the expected index path files/test_bucket/dial-rag-index/7b2c7c63"
+                        "/4edd181b/4e740914/a25bbca2/14293b02/3a6860ca/93141399/c018f739/index.bin.",
+                    }
+                ]
+            }
+        },
+    }

--- a/tests/test_attachment_stored.py
+++ b/tests/test_attachment_stored.py
@@ -125,6 +125,7 @@ async def test_load_document_success(
         request_context,
         indexing_task,
         index_storage,
+        dial_api_client,
         config=request_config,
     )
     assert isinstance(doc_record, DocumentRecord)
@@ -172,6 +173,7 @@ async def test_load_document_invalid_document(
                 index_url=index_url,
             ),
             index_storage,
+            dial_api_client,
             config=request_config,
         )
     assert isinstance(exc_info.value.__cause__, InvalidDocumentError)

--- a/tests/test_attachment_stored.py
+++ b/tests/test_attachment_stored.py
@@ -11,9 +11,9 @@ from aidial_rag.document_loaders import load_attachment
 from aidial_rag.document_record import DocumentRecord
 from aidial_rag.documents import load_document
 from aidial_rag.errors import DocumentProcessingError, InvalidDocumentError
-from aidial_rag.index_storage import IndexStorageHolder, link_to_index_url
+from aidial_rag.index_storage import IndexStorageHolder
 from aidial_rag.indexing_config import IndexingConfig
-from aidial_rag.indexing_task import IndexingTask
+from aidial_rag.indexing_task import IndexingTask, link_to_index_url
 from aidial_rag.request_context import RequestContext
 from aidial_rag.resources.dial_limited_resources import DialLimitedResources
 from tests.utils.user_limits_mock import user_limits_mock

--- a/tests/utils/response_helpers.py
+++ b/tests/utils/response_helpers.py
@@ -1,5 +1,9 @@
+import json
 import re
 from typing import Any, Dict, List
+
+from aidial_rag.index_mime_type import INDEX_MIME_TYPE
+from aidial_rag.indexing_api import IndexingResponse
 
 
 def get_stage_names(response_json: Dict[str, Any]) -> List[str]:
@@ -10,3 +14,32 @@ def get_stage_names(response_json: Dict[str, Any]) -> List[str]:
         ).strip()  # cut [0.03s] at the end of the stage name
         for stage in stages
     ]
+
+
+def get_attachments(json_response):
+    attachments = json_response["choices"][0]["message"]["custom_content"][
+        "attachments"
+    ]
+
+    return attachments
+
+
+def get_index_attachments(attachments):
+    index_attachments_result = [
+        attachment
+        for attachment in attachments
+        if attachment["type"] == INDEX_MIME_TYPE
+    ]
+
+    return index_attachments_result
+
+
+def get_indexing_result_json(attachments):
+    indexing_result_attachment = next(
+        attachment
+        for attachment in attachments
+        if attachment["type"] == IndexingResponse.CONTENT_TYPE
+    )
+
+    indexing_result_json = json.loads(indexing_result_attachment["data"])
+    return indexing_result_json


### PR DESCRIPTION
### Description of changes

If the index path provided by the used is pointing to the dial-rag bucket, check that the path matched with the expected path for the index to avoid overwriting the indexes of another documents.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
