### PR TITLE
fix: make mime types consistent between different api attachments

### DIFF
--- a/aidial_rag/app.py
+++ b/aidial_rag/app.py
@@ -146,14 +146,14 @@ async def _run_retrieval(
         "doc_records_links": document_records_links,
     }
 
-    retrieval_results = await retrieval_chain.pick("retrieval_results").ainvoke(
-        chain_input
-    )
+    retrieval_response = await retrieval_chain.pick(
+        "retrieval_response"
+    ).ainvoke(chain_input)
 
     choice.add_attachment(
-        title="Retrieval results",
-        type=retrieval_results.CONTENT_TYPE,
-        data=retrieval_results.model_dump_json(indent=2),
+        title="Retrieval response",
+        type=retrieval_response.CONTENT_TYPE,
+        data=retrieval_response.model_dump_json(indent=2),
     )
 
 

--- a/aidial_rag/index_mime_type.py
+++ b/aidial_rag/index_mime_type.py
@@ -1,7 +1,7 @@
 import re
 
-INDEX_MIME_TYPE = "application/x.aidial-rag-index.v0"
-INDEX_MIME_TYPES_REGEX = re.compile(r"^application/x\.aidial-rag-index\..*$")
+INDEX_MIME_TYPE = "application/x.aidial-rag.index.v0"
+INDEX_MIME_TYPES_REGEX = re.compile(r"^application/x\.aidial-rag\.index\..*$")
 
 
 assert INDEX_MIME_TYPES_REGEX.match(INDEX_MIME_TYPE), (

--- a/aidial_rag/qa_chain.py
+++ b/aidial_rag/qa_chain.py
@@ -20,7 +20,7 @@ from langchain_core.runnables import Runnable, chain
 from aidial_rag.llm import create_llm
 from aidial_rag.qa_chain_config import ChatChainConfig
 from aidial_rag.request_context import RequestContext
-from aidial_rag.retrieval_api import RetrievalResults
+from aidial_rag.retrieval_api import RetrievalResponse
 
 logger = logging.getLogger(__name__)
 
@@ -78,11 +78,11 @@ def image_element(image: str) -> MessageElement:
 
 
 def create_docs_message(
-    retrieval_results: RetrievalResults,
+    retrieval_response: RetrievalResponse,
 ) -> List[MessageElement]:
     docs_message: List[MessageElement] = []
     docs_message.append(text_element("<context>"))
-    for i, chunk in enumerate(retrieval_results.chunks, start=1):
+    for i, chunk in enumerate(retrieval_response.chunks, start=1):
         attributes = format_attributes(
             id=i,
             page_number=chunk.page.number if chunk.page else None,
@@ -91,7 +91,7 @@ def create_docs_message(
         docs_message.append(text_element(f"<doc {attributes}>\n{chunk.text}\n"))
 
         if chunk.page is not None and chunk.page.image_index is not None:
-            image = retrieval_results.images[chunk.page.image_index]
+            image = retrieval_response.images[chunk.page.image_index]
             docs_message.append(image_element(image.data))
 
         docs_message.append(text_element("</doc>\n"))
@@ -111,8 +111,8 @@ async def create_chat_prompt(input: Dict[str, Any]) -> List[BaseMessage]:
         config.system_prompt_template_override or DEFAULT_SYSTEM_TEMPLATE
     )
 
-    retrieval_results = input["retrieval_results"]
-    docs_message = create_docs_message(retrieval_results)
+    retrieval_response = input["retrieval_response"]
+    docs_message = create_docs_message(retrieval_response)
 
     template = ChatPromptTemplate.from_messages(
         [

--- a/aidial_rag/retrieval_api.py
+++ b/aidial_rag/retrieval_api.py
@@ -66,11 +66,11 @@ class Chunk(BaseModel):
     )
 
 
-class RetrievalResults(BaseModel):
-    """Results of the Dial RAG retrieval process."""
+class RetrievalResponse(BaseModel):
+    """Response with the results of the Dial RAG retrieval process."""
 
     CONTENT_TYPE: ClassVar[str] = (
-        "application/vnd.aidial.rag.retrieval-results+json"
+        "application/x.aidial-rag.retrieval-response+json"
     )
 
     chunks: List[Chunk] = Field(

--- a/aidial_rag/retrieval_chain.py
+++ b/aidial_rag/retrieval_chain.py
@@ -25,7 +25,7 @@ from aidial_rag.retrieval_api import (
     Chunk,
     Image,
     Page,
-    RetrievalResults,
+    RetrievalResponse,
     Source,
 )
 from aidial_rag.retrievers.all_documents_retriever import AllDocumentsRetriever
@@ -128,10 +128,10 @@ async def create_image_by_page(
 
 
 @chain
-async def create_retrieval_results(
+async def create_retrieval_response(
     input: Dict[str, Any],
-) -> RetrievalResults:
-    """Create retrieval results from the input data."""
+) -> RetrievalResponse:
+    """Create retrieval response from the input data."""
     doc_records: List[DocumentRecord] = input.get("doc_records", [])
     doc_records_links: List[AttachmentLink] = input.get("doc_records_links", [])
     index_items: List[Document] = input.get("found_items", [])
@@ -177,7 +177,7 @@ async def create_retrieval_results(
 
         chunks.append(chunk_data)
 
-    return RetrievalResults(
+    return RetrievalResponse(
         chunks=chunks,
         images=images,
     )
@@ -275,6 +275,6 @@ async def create_retrieval_chain(
         .assign(query=query_chain)
         .assign(found_items=(itemgetter("query") | retriever))
         .assign(image_by_page=create_image_by_page)
-        .assign(retrieval_results=create_retrieval_results)
+        .assign(retrieval_response=create_retrieval_response)
     )
     return retrieval_chain

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,13 +31,13 @@ To run the Indexing or Retrieval part of the RAG pipeline, you need to set the `
 
 The DIAL RAG uses special type of attachments to represent the index files for the documents. The index attachments are used both as output of the indexing requests and as an input for the retrieval or RAG requests.
 
-The DIAL RAG recognizes the index attachment by MIME types matching `application/x.aidial-rag-index.*`. Currently, only index type `application/x.aidial-rag-index.v0` is supported, but it may be extended in the new versions of the DIAL RAG.
+The DIAL RAG recognizes the index attachment by MIME types matching `application/x.aidial-rag.index.*`. Currently, only index type `application/x.aidial-rag.index.v0` is supported, but it may be extended in the new versions of the DIAL RAG.
 
 The index attachment is based on the [DIAL Unified API attachments](https://docs.dialx.ai/tutorials/developers/chat/chat-objects#attachments) and has the following structure:
 
 ```json
 {
-    "type": "application/x.aidial-rag-index.v0",
+    "type": "application/x.aidial-rag.index.v0",
     "url": "files/<bucket>/<path to index file>",
     "reference_url": "<url to the document the index file is based on>"
 }
@@ -90,7 +90,7 @@ Example of response message with successful indexing results for the above reque
     "custom_content": {
         "attachments": [
             {
-                "type": "application/x.aidial-rag-index.v0",
+                "type": "application/x.aidial-rag.index.v0",
                 "url": "files/<dial-rag bucket>/<path inside dial-rag bucket>/index.bin",
                 "reference_url": "files/<bucket>/my_document.pdf"
             },
@@ -155,7 +155,7 @@ Example of the indexing request for a single `my_document.pdf` document with a s
                         "url": "files/<bucket>/my_document.pdf"
                     },
                     {
-                        "type": "application/x.aidial-rag-index.v0",
+                        "type": "application/x.aidial-rag.index.v0",
                         "url": "files/<bucket>/appdata/my_document.index",
                         "reference_url": "files/<bucket>/my_document.pdf"
                     }
@@ -203,9 +203,9 @@ Example of the retrieval request for a single `my_document.pdf` document:
 }
 ```
 
-The response for this request will have a message with an empty content (because the generation of the final response is not run). The retrieval results will be as a JSON document in the attachment with MIME type `application/vnd.aidial.rag.retrieval-results+json` and follows the [Retrieval results schema](./retrieval_results.generated.schema.json).
+The response for this request will have a message with an empty content (because the generation of the final response is not run). The retrieval response will be as a JSON document in the attachment with MIME type `application/x.aidial-rag.retrieval-response+json` and follows the [Retrieval response schema](./retrieval_response.generated.schema.json).
 
-Example of the retrieval results JSON for the above request:
+Example of the retrieval response JSON for the above request:
 ```json
 {
     "chunks": [
@@ -233,7 +233,7 @@ Example of the retrieval results JSON for the above request:
 }
 ```
 
-The retrieval results JSON contains two lists:
+The retrieval response JSON contains two lists:
 - **`chunks`** - a list of retrieved document chunks in the order of relevance to the user query. Each chunk contains:
   - **`attachment_url`** - the URL of the attached document, the chunk belongs to. Exactly matches with the `attachment.url` field in the request.
   - **`source`** - the source this chunk belongs to. The source could be a document or some part of the document, like a page or a section. The source object contains:

--- a/docs/indexing_api_example.ipynb
+++ b/docs/indexing_api_example.ipynb
@@ -226,7 +226,7 @@
    "id": "a0ce9be2",
    "metadata": {},
    "source": [
-    "The response will contain the attachments with `type` equal to `application/x.aidial-rag-index.v0` pointing to the the resulting indexing files. The `reference_url` field in the attachment will contain the URL to the original document file."
+    "The response will contain the attachments with `type` equal to `application/x.aidial-rag.index.v0` pointing to the the resulting indexing files. The `reference_url` field in the attachment will contain the URL to the original document file."
    ]
   },
   {
@@ -238,7 +238,7 @@
     {
      "data": {
       "text/plain": [
-       "{'type': 'application/x.aidial-rag-index.v0',\n",
+       "{'type': 'application/x.aidial-rag.index.v0',\n",
        " 'url': 'files/DaEaz3wZq4g26J5J7BPmGC/dial-rag-index/cbfce81c/02c84941/80408552/957d0c77/dbad09f5/85ab2c5c/56b3acbc/5fd03e99/index.bin',\n",
        " 'reference_url': 'files/6iTkeGUs2CvUehhYLmMYXB/data/alps_wiki.pdf'}"
       ]
@@ -255,7 +255,7 @@
     "    (\n",
     "        attachment\n",
     "        for attachment in response_attachments\n",
-    "        if attachment[\"type\"] == \"application/x.aidial-rag-index.v0\"\n",
+    "        if attachment[\"type\"] == \"application/x.aidial-rag.index.v0\"\n",
     "    ),\n",
     "    None,\n",
     ")\n",
@@ -306,7 +306,7 @@
     "\n",
     "You can use the same indexing attachment format to specify a custom path for the indexing files. This is useful if your application need to manage the indexing files by itself. For example, it you want to pre-index some document and you need to copy the index file and the document to some other location (for example, during the publishing of your application).\n",
     "\n",
-    "To do this, the attachment should have `type` equal to `application/x.aidial-rag-index.v0`, `reference_url` pointing to the url original document file, and `url` pointing to the desired relative url for the indexing files.\n",
+    "To do this, the attachment should have `type` equal to `application/x.aidial-rag.index.v0`, `reference_url` pointing to the url original document file, and `url` pointing to the desired relative url for the indexing files.\n",
     "\n",
     "**Note**: the DIAL RAG should have write access to the index file path specified in the request. For this example we use `appdata/dial-rag` in our bucket which will be available for DIAL RAG with write access. See [Files sharing](https://docs.dialx.ai/platform/core/per-request-keys#files-sharing) for more details on how to share an access to the files in the DIAL."
    ]
@@ -319,7 +319,7 @@
    "outputs": [],
    "source": [
     "pdf_index_with_custom_path = {\n",
-    "    \"type\": \"application/x.aidial-rag-index.v0\",\n",
+    "    \"type\": \"application/x.aidial-rag.index.v0\",\n",
     "    \"reference_url\": pdf_file_attachment[\"url\"],\n",
     "    \"url\": f\"files/{bucket}/appdata/dial-rag/custom_index.bin\",\n",
     "}\n",
@@ -359,7 +359,7 @@
     {
      "data": {
       "text/plain": [
-       "[{'type': 'application/x.aidial-rag-index.v0',\n",
+       "[{'type': 'application/x.aidial-rag.index.v0',\n",
        "  'url': 'files/6iTkeGUs2CvUehhYLmMYXB/appdata/dial-rag/custom_index.bin',\n",
        "  'reference_url': 'files/6iTkeGUs2CvUehhYLmMYXB/data/alps_wiki.pdf'},\n",
        " {'type': 'application/x.aidial-rag.indexing-response+json',\n",
@@ -397,7 +397,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The highest mountain in the Alps is Mont Blanc, which spans the French-Italian border and has an elevation of 4,810 meters (15,781 feet) [1].\n"
+      "The highest mountain in the Alps is Mont Blanc, which spans the French-Italian border and has an elevation of 4,810 meters (15,781 feet) [1][2].\n"
      ]
     }
    ],

--- a/docs/retrieval_api_example.ipynb
+++ b/docs/retrieval_api_example.ipynb
@@ -231,7 +231,7 @@
    "source": [
     "## Retrieval results\n",
     "\n",
-    "The retrieval result contains the attachment with type `application/vnd.aidial.rag.retrieval-results+json`. This attachment contains the retrieval results in JSON format."
+    "The response for the retrieval request contains the attachment with type `application/x.aidial-rag.retrieval-response+json`. This attachment contains the results of the RAG retrieval the in JSON format."
    ]
   },
   {
@@ -242,20 +242,20 @@
    "outputs": [],
    "source": [
     "response_attachments = response.choices[0].message.custom_content[\"attachments\"]\n",
-    "retrieval_results_attachment = next(\n",
+    "retrieval_response_attachment = next(\n",
     "    (\n",
     "        attachment\n",
     "        for attachment in response_attachments\n",
     "        if attachment[\"type\"]\n",
-    "        == \"application/vnd.aidial.rag.retrieval-results+json\"\n",
+    "        == \"application/x.aidial-rag.retrieval-response+json\"\n",
     "    ),\n",
     "    None,\n",
     ")\n",
     "\n",
-    "retrieval_results_json = json.loads(retrieval_results_attachment[\"data\"])\n",
+    "retrieval_response_json = json.loads(retrieval_response_attachment[\"data\"])\n",
     "\n",
-    "chunks = retrieval_results_json[\"chunks\"]\n",
-    "images = retrieval_results_json.get(\"images\", [])"
+    "chunks = retrieval_response_json[\"chunks\"]\n",
+    "images = retrieval_response_json.get(\"images\", [])"
    ]
   },
   {
@@ -263,7 +263,7 @@
    "id": "1e439b3b",
    "metadata": {},
    "source": [
-    "The retrieval results contain the list of chunks in the order of relevance. Additionally, it contains the list of images associated with the retrieved.\n",
+    "The retrieval response contains the list of chunks in the order of relevance. Additionally, it contains the list of images associated with the retrieved.\n",
     "\n",
     "Let's look at the most relevant chunk, which is the first one in the list:"
    ]
@@ -302,7 +302,7 @@
    "id": "e1bfbf87",
    "metadata": {},
    "source": [
-    "Let's display top 5 chunks from the retrieval results as a table using Pandas:"
+    "Let's display top 5 chunks from the retrieval response as a table using Pandas:"
    ]
   },
   {

--- a/docs/retrieval_response.generated.schema.json
+++ b/docs/retrieval_response.generated.schema.json
@@ -123,7 +123,7 @@
       "type": "object"
     }
   },
-  "description": "Results of the Dial RAG retrieval process.",
+  "description": "Response with the results of the Dial RAG retrieval process.",
   "properties": {
     "chunks": {
       "description": "List of chunks found by retriever in the order of their relevance.",
@@ -142,6 +142,6 @@
       "type": "array"
     }
   },
-  "title": "RetrievalResults",
+  "title": "RetrievalResponse",
   "type": "object"
 }

--- a/noxfile.py
+++ b/noxfile.py
@@ -78,8 +78,8 @@ def update_docs(session):
     session.run(
         "python",
         "./generate_json_schema.py",
-        "aidial_rag.retrieval_api.RetrievalResults",
-        "docs/retrieval_results.generated.schema.json",
+        "aidial_rag.retrieval_api.RetrievalResponse",
+        "docs/retrieval_response.generated.schema.json",
     )
     session.run(
         "python",

--- a/tests/test_app_indexing.py
+++ b/tests/test_app_indexing.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 from aidial_rag.app import create_app
 from aidial_rag.app_config import AppConfig
 from aidial_rag.index_mime_type import INDEX_MIME_TYPE
-from aidial_rag.retrieval_api import Page, RetrievalResults, Source
+from aidial_rag.retrieval_api import Page, RetrievalResponse, Source
 from tests.utils.config_override import (
     description_index_retries_override,  # noqa: F401
 )
@@ -123,12 +123,14 @@ async def test_indexing_request(attachments):
     attachments = get_attachments(json_response)
     assert len(attachments) == 1
     attachment = attachments[0]
-    assert attachment["type"] == RetrievalResults.CONTENT_TYPE
-    assert attachment["title"] == "Retrieval results"
+    assert attachment["type"] == RetrievalResponse.CONTENT_TYPE
+    assert attachment["title"] == "Retrieval response"
 
-    retrieval_results = RetrievalResults.model_validate_json(attachment["data"])
-    assert len(retrieval_results.chunks) == 13
-    chunk_from_image = retrieval_results.chunks[0]
+    retrieval_response = RetrievalResponse.model_validate_json(
+        attachment["data"]
+    )
+    assert len(retrieval_response.chunks) == 13
+    chunk_from_image = retrieval_response.chunks[0]
     assert (
         chunk_from_image.attachment_url
         == "files/6iTkeGUs2CvUehhYLmMYXB/test_image.png"
@@ -143,13 +145,13 @@ async def test_indexing_request(attachments):
         image_index=0,
     )
 
-    assert len(retrieval_results.images) == 1
-    assert retrieval_results.images[0].mime_type == "image/png"
+    assert len(retrieval_response.images) == 1
+    assert retrieval_response.images[0].mime_type == "image/png"
     assert re.match(
-        r"^iVBORw0KGgoAAAA.*CYII=$", retrieval_results.images[0].data
+        r"^iVBORw0KGgoAAAA.*CYII=$", retrieval_response.images[0].data
     )
 
-    for chunk in retrieval_results.chunks[1:]:
+    for chunk in retrieval_response.chunks[1:]:
         assert (
             chunk.attachment_url
             == "files/6iTkeGUs2CvUehhYLmMYXB/alps_wiki.html"
@@ -160,8 +162,8 @@ async def test_indexing_request(attachments):
         )
         assert chunk.page is None
 
-    assert retrieval_results.chunks[1].text is not None
-    assert retrieval_results.chunks[1].text.startswith(
+    assert retrieval_response.chunks[1].text is not None
+    assert retrieval_response.chunks[1].text.startswith(
         "Techniques and tools Quantitative Cartography"
     )
 

--- a/tests/test_app_retrieval.py
+++ b/tests/test_app_retrieval.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 
 from aidial_rag.app import create_app
 from aidial_rag.app_config import AppConfig
-from aidial_rag.retrieval_api import Page, RetrievalResults, Source
+from aidial_rag.retrieval_api import Page, RetrievalResponse, Source
 from tests.utils.config_override import (
     description_index_retries_override,  # noqa: F401
 )
@@ -57,12 +57,14 @@ async def test_retrieval_request(attachments):
     ]
     assert len(attachments) == 1
     attachment = attachments[0]
-    assert attachment["type"] == RetrievalResults.CONTENT_TYPE
-    assert attachment["title"] == "Retrieval results"
+    assert attachment["type"] == RetrievalResponse.CONTENT_TYPE
+    assert attachment["title"] == "Retrieval response"
 
-    retrieval_results = RetrievalResults.model_validate_json(attachment["data"])
-    assert len(retrieval_results.chunks) == 13
-    chunk_from_image = retrieval_results.chunks[0]
+    retrieval_response = RetrievalResponse.model_validate_json(
+        attachment["data"]
+    )
+    assert len(retrieval_response.chunks) == 13
+    chunk_from_image = retrieval_response.chunks[0]
     assert (
         chunk_from_image.attachment_url
         == "files/6iTkeGUs2CvUehhYLmMYXB/test_image.png"
@@ -77,13 +79,13 @@ async def test_retrieval_request(attachments):
         image_index=0,
     )
 
-    assert len(retrieval_results.images) == 1
-    assert retrieval_results.images[0].mime_type == "image/png"
+    assert len(retrieval_response.images) == 1
+    assert retrieval_response.images[0].mime_type == "image/png"
     assert re.match(
-        r"^iVBORw0KGgoAAAA.*CYII=$", retrieval_results.images[0].data
+        r"^iVBORw0KGgoAAAA.*CYII=$", retrieval_response.images[0].data
     )
 
-    for chunk in retrieval_results.chunks[1:]:
+    for chunk in retrieval_response.chunks[1:]:
         assert (
             chunk.attachment_url
             == "files/6iTkeGUs2CvUehhYLmMYXB/alps_wiki.html"
@@ -94,8 +96,8 @@ async def test_retrieval_request(attachments):
         )
         assert chunk.page is None
 
-    assert retrieval_results.chunks[1].text is not None
-    assert retrieval_results.chunks[1].text.startswith(
+    assert retrieval_response.chunks[1].text is not None
+    assert retrieval_response.chunks[1].text.startswith(
         "Techniques and tools Quantitative Cartography"
     )
 


### PR DESCRIPTION
### Description of changes

Fix mime types used for index, indexing response and retrieval response to start with `application/x.aidial-rag.`.
`RetrievalResults` renamed to `RetrievalResponse` to make names more consistent as well.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
