### PR TITLE
fix: use connection pool per request

### DIFF
--- a/aidial_rag/attachment_link.py
+++ b/aidial_rag/attachment_link.py
@@ -61,9 +61,10 @@ def to_dial_metadata_url(
     if not request_context.is_dial_url(absolute_url):
         return None
 
-    return urljoin(
+    absolute_metadata_url = urljoin(
         request_context.dial_metadata_base_url, link, allow_fragments=True
     )
+    return to_dial_relative_url(request_context, absolute_metadata_url)
 
 
 class AttachmentLink(BaseModel):

--- a/aidial_rag/dial_api_client.py
+++ b/aidial_rag/dial_api_client.py
@@ -1,19 +1,20 @@
 import io
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
 
 import aiohttp
 
-from aidial_rag.request_context import RequestContext
+from aidial_rag.dial_config import DialConfig
 
 
-async def _get_bucket_id(dial_base_url, headers: dict) -> str:
+async def _get_bucket_id(session: aiohttp.ClientSession, headers: dict) -> str:
     relative_url = (
         "bucket"  # /v1/ is already included in the base url for the Dial API
     )
-    async with aiohttp.ClientSession(base_url=dial_base_url) as session:
-        async with session.get(relative_url, headers=headers) as response:
-            response.raise_for_status()
-            data = await response.json()
-            return data["bucket"]
+    async with session.get(relative_url, headers=headers) as response:
+        response.raise_for_status()
+        data = await response.json()
+        return data["bucket"]
 
 
 def _to_form_data(key: str, data: bytes, content_type: str) -> aiohttp.FormData:
@@ -25,39 +26,36 @@ def _to_form_data(key: str, data: bytes, content_type: str) -> aiohttp.FormData:
 
 
 class DialApiClient:
-    def __init__(self, dial_api_base_url: str, headers: dict, bucket_id: str):
+    def __init__(self, client_session: aiohttp.ClientSession, bucket_id: str):
+        self._client_session = client_session
         self.bucket_id = bucket_id
 
-        self._dial_api_base_url = dial_api_base_url
-        self._headers = headers
+    @property
+    def session(self) -> aiohttp.ClientSession:
+        return self._client_session
 
     async def get_file(self, relative_url: str) -> bytes | None:
-        async with aiohttp.ClientSession(
-            base_url=self._dial_api_base_url
-        ) as session:
-            async with session.get(
-                relative_url, headers=self._headers
-            ) as response:
-                response.raise_for_status()
-                return await response.read()
+        async with self.session.get(relative_url) as response:
+            response.raise_for_status()
+            return await response.read()
 
     async def put_file(
         self, relative_url: str, data: bytes, content_type: str
     ) -> dict:
-        async with aiohttp.ClientSession(
-            base_url=self._dial_api_base_url
-        ) as session:
-            form_data = _to_form_data(relative_url, data, content_type)
-            async with session.put(
-                relative_url, data=form_data, headers=self._headers
-            ) as response:
-                response.raise_for_status()
-                return await response.json()
+        form_data = _to_form_data(relative_url, data, content_type)
+        async with self.session.put(relative_url, data=form_data) as response:
+            response.raise_for_status()
+            return await response.json()
 
 
+@asynccontextmanager
 async def create_dial_api_client(
-    request_context: RequestContext,
-) -> DialApiClient:
-    headers = request_context.get_api_key_headers()
-    bucket_id = await _get_bucket_id(request_context.dial_base_url, headers)
-    return DialApiClient(request_context.dial_base_url, headers, bucket_id)
+    config: DialConfig,
+) -> AsyncGenerator[DialApiClient, None]:
+    dial_base_url = f"{config.dial_url}/v1/"
+    headers = {"api-key": config.api_key.get_secret_value()}
+    async with aiohttp.ClientSession(
+        base_url=dial_base_url, headers=headers
+    ) as session:
+        bucket_id = await _get_bucket_id(session, headers)
+        yield DialApiClient(session, bucket_id)

--- a/aidial_rag/dial_api_client.py
+++ b/aidial_rag/dial_api_client.py
@@ -52,10 +52,9 @@ class DialApiClient:
 async def create_dial_api_client(
     config: DialConfig,
 ) -> AsyncGenerator[DialApiClient, None]:
-    dial_base_url = f"{config.dial_url}/v1/"
     headers = {"api-key": config.api_key.get_secret_value()}
     async with aiohttp.ClientSession(
-        base_url=dial_base_url, headers=headers
+        base_url=config.dial_base_url, headers=headers
     ) as session:
         bucket_id = await _get_bucket_id(session, headers)
         yield DialApiClient(session, bucket_id)

--- a/aidial_rag/dial_config.py
+++ b/aidial_rag/dial_config.py
@@ -6,3 +6,7 @@ from aidial_rag.base_config import BaseConfig
 class DialConfig(BaseConfig):
     dial_url: str
     api_key: SecretStr
+
+    @property
+    def dial_base_url(self) -> str:
+        return f"{self.dial_url}/v1/"

--- a/aidial_rag/dial_user_limits.py
+++ b/aidial_rag/dial_user_limits.py
@@ -1,7 +1,6 @@
-import aiohttp
 from pydantic import BaseModel, Field
 
-from aidial_rag.dial_config import DialConfig
+from aidial_rag.dial_api_client import DialApiClient
 
 
 class TokenStats(BaseModel):
@@ -20,18 +19,15 @@ class UserLimitsForModel(BaseModel):
 
 
 async def get_user_limits_for_model(
-    dial_config: DialConfig, deployment_name: str
+    dial_api_client: DialApiClient, deployment_name: str
 ) -> UserLimitsForModel:
     """Returns the user limits for the specified model deployment.
 
     See https://epam-rail.com/dial_api#tag/Limits for the API documentation.
     """
-    headers = {"Api-Key": dial_config.api_key.get_secret_value()}
-    limits_url = (
-        f"{dial_config.dial_url}/v1/deployments/{deployment_name}/limits"
-    )
-    async with aiohttp.ClientSession() as session:
-        async with session.get(limits_url, headers=headers) as response:
-            response.raise_for_status()
-            limits_json = await response.json()
-            return UserLimitsForModel.model_validate(limits_json)
+
+    limits_relative_url = f"deployments/{deployment_name}/limits"
+    async with dial_api_client.session.get(limits_relative_url) as response:
+        response.raise_for_status()
+        limits_json = await response.json()
+        return UserLimitsForModel.model_validate(limits_json)

--- a/aidial_rag/request_context.py
+++ b/aidial_rag/request_context.py
@@ -1,8 +1,9 @@
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 
 from aidial_sdk.chat_completion import Choice, Request, Response
 from pydantic import BaseModel, SecretStr
 
+from aidial_rag.dial_api_client import DialApiClient, create_dial_api_client
 from aidial_rag.dial_config import DialConfig
 from aidial_rag.dial_user_limits import get_user_limits_for_model
 from aidial_rag.errors import convert_and_log_exceptions
@@ -13,6 +14,7 @@ class RequestContext(BaseModel):
     dial_url: str
     api_key: SecretStr
     choice: Choice
+    dial_api_client: DialApiClient
     dial_limited_resources: DialLimitedResources
 
     class Config:
@@ -44,22 +46,26 @@ class RequestContext(BaseModel):
         return {"api-key": self.api_key.get_secret_value()}
 
 
-@contextmanager
-def create_request_context(dial_url: str, request: Request, response: Response):
+@asynccontextmanager
+async def create_request_context(
+    dial_url: str, request: Request, response: Response
+):
     with convert_and_log_exceptions():
         with response.create_single_choice() as choice:
             dial_config = DialConfig(
                 dial_url=dial_url, api_key=SecretStr(request.api_key)
             )
 
-            request_context = RequestContext(
-                dial_url=dial_url,
-                api_key=dial_config.api_key,
-                choice=choice,
-                dial_limited_resources=DialLimitedResources(
-                    lambda model_name: get_user_limits_for_model(
-                        dial_config, model_name
-                    )
-                ),
-            )
-            yield request_context
+            async with create_dial_api_client(dial_config) as dial_api_client:
+                request_context = RequestContext(
+                    dial_url=dial_url,
+                    api_key=dial_config.api_key,
+                    choice=choice,
+                    dial_api_client=dial_api_client,
+                    dial_limited_resources=DialLimitedResources(
+                        lambda model_name: get_user_limits_for_model(
+                            dial_api_client, model_name
+                        )
+                    ),
+                )
+                yield request_context

--- a/tests/test_load_documents.py
+++ b/tests/test_load_documents.py
@@ -1,4 +1,5 @@
 import sys
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -20,8 +21,9 @@ async def load_document(name):
         display_name=name,
     )
 
+    dial_api_client = MagicMock()
     _file_name, content_type, buffer = await load_attachment(
-        attachment_link, {}
+        dial_api_client, attachment_link
     )
     mime_type, _ = parse_content_type(content_type)
     chunks = await parse_document(

--- a/tests/test_retrievers.py
+++ b/tests/test_retrievers.py
@@ -1,12 +1,13 @@
 import sys
 from operator import itemgetter
 
+import aiohttp
 import pytest
 from langchain.schema.runnable import RunnablePassthrough
 from pydantic import SecretStr
 
 from aidial_rag.attachment_link import AttachmentLink
-from aidial_rag.dial_api_client import create_dial_api_client
+from aidial_rag.dial_api_client import DialApiClient
 from aidial_rag.dial_config import DialConfig
 from aidial_rag.document_loaders import load_attachment, parse_document
 from aidial_rag.document_record import (
@@ -44,7 +45,6 @@ async def run_retrevier(retriever, doc_records, query):
     )
 
 
-@pytest.mark.skip
 @pytest.mark.asyncio
 async def test_retrievers(local_server):
     name = "alps_wiki.pdf"
@@ -60,9 +60,11 @@ async def test_retrievers(local_server):
         dial_url=f"http://localhost:{PORT}", api_key=SecretStr("")
     )
 
-    async with create_dial_api_client(dial_config) as dial_api_client:
+    async with aiohttp.ClientSession(
+        base_url=dial_config.dial_base_url
+    ) as session:
         _file_name, content_type, buffer = await load_attachment(
-            dial_api_client,
+            DialApiClient(session, bucket_id=""),
             attachment_link,
         )
 
@@ -115,7 +117,6 @@ async def test_retrievers(local_server):
     )
 
 
-@pytest.mark.skip
 @pytest.mark.asyncio
 async def test_pdf_with_no_text(local_server):
     name = "test_pdf_with_image.pdf"
@@ -131,9 +132,11 @@ async def test_pdf_with_no_text(local_server):
         dial_url=f"http://localhost:{PORT}", api_key=SecretStr("")
     )
 
-    async with create_dial_api_client(dial_config) as dial_api_client:
+    async with aiohttp.ClientSession(
+        base_url=dial_config.dial_base_url
+    ) as session:
         _file_name, content_type, buffer = await load_attachment(
-            dial_api_client,
+            DialApiClient(session, bucket_id=""),
             attachment_link,
         )
 

--- a/tests/test_retrievers.py
+++ b/tests/test_retrievers.py
@@ -3,8 +3,11 @@ from operator import itemgetter
 
 import pytest
 from langchain.schema.runnable import RunnablePassthrough
+from pydantic import SecretStr
 
 from aidial_rag.attachment_link import AttachmentLink
+from aidial_rag.dial_api_client import create_dial_api_client
+from aidial_rag.dial_config import DialConfig
 from aidial_rag.document_loaders import load_attachment, parse_document
 from aidial_rag.document_record import (
     FORMAT_VERSION,
@@ -41,6 +44,7 @@ async def run_retrevier(retriever, doc_records, query):
     )
 
 
+@pytest.mark.skip
 @pytest.mark.asyncio
 async def test_retrievers(local_server):
     name = "alps_wiki.pdf"
@@ -52,9 +56,16 @@ async def test_retrievers(local_server):
         display_name=name,
     )
 
-    _file_name, content_type, buffer = await load_attachment(
-        attachment_link, {}
+    dial_config = DialConfig(
+        dial_url=f"http://localhost:{PORT}", api_key=SecretStr("")
     )
+
+    async with create_dial_api_client(dial_config) as dial_api_client:
+        _file_name, content_type, buffer = await load_attachment(
+            dial_api_client,
+            attachment_link,
+        )
+
     mime_type, _ = parse_content_type(content_type)
     text_chunks = await parse_document(
         sys.stderr, buffer, mime_type, attachment_link, mime_type
@@ -104,6 +115,7 @@ async def test_retrievers(local_server):
     )
 
 
+@pytest.mark.skip
 @pytest.mark.asyncio
 async def test_pdf_with_no_text(local_server):
     name = "test_pdf_with_image.pdf"
@@ -115,9 +127,16 @@ async def test_pdf_with_no_text(local_server):
         display_name=name,
     )
 
-    _file_name, content_type, buffer = await load_attachment(
-        attachment_link, {}
+    dial_config = DialConfig(
+        dial_url=f"http://localhost:{PORT}", api_key=SecretStr("")
     )
+
+    async with create_dial_api_client(dial_config) as dial_api_client:
+        _file_name, content_type, buffer = await load_attachment(
+            dial_api_client,
+            attachment_link,
+        )
+
     mime_type, _ = parse_content_type(content_type)
     text_chunks = await parse_document(
         sys.stderr, buffer, mime_type, attachment_link, mime_type


### PR DESCRIPTION
### Description of changes

Create a single connection pool per request to avoid using too much connections of the dial core.
To do this, DialApiClient is created within the RequestContext to store the aiohttp.ClientSession to use for the requests to the dial core. This session accepts only dial relative urls and already has necessary api-key headers.
Metadata url in the AttachmentLink is now represented as a relative url to be able to use it in the DialApiClient session.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
