### PR TITLE
fix: use the same threadPool for query and indexing embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,18 +80,6 @@ Enables support of debug commands in the messages. Should be `false` for prod en
 
 Process pool for document parsing, image extraction and similar CPU-bound tasks. Is set to `max(1, CPU_COUNT - 2)` to leave some CPU cores for other tasks.
 
-##### `DIAL_RAG__CPU_POOLS__INDEXING_EMBEDDINGS_POOL`
-
-*Optional*, default value: `1`
-
-Embedding process itself uses multiple cores. Should be `1`, unless you have a lot of cores and can explicitly see the underutilisation (i.e. you only have a very small documents in the requests).
-
-##### `DIAL_RAG__CPU_POOLS__QUERY_EMBEDDINGS_POOL`
-
-*Optional*, default value: `1`
-
-Embedding process for the query. Should be `1`, unless you have a lot of cores.
-
 ##### `USE_DIAL_FILE_STORAGE`
 
 *Optional*, default value: `False`

--- a/aidial_rag/embeddings/embeddings.py
+++ b/aidial_rag/embeddings/embeddings.py
@@ -13,10 +13,7 @@ from langchain_community.embeddings import HuggingFaceBgeEmbeddings
 from aidial_rag.batched import batched_map_with_progress
 from aidial_rag.content_stream import SupportsWriteStr
 from aidial_rag.embeddings.detect_device import DeviceType, detect_device
-from aidial_rag.resources.cpu_pools import (
-    run_in_indexing_embeddings_pool,
-    run_in_query_embeddings_pool,
-)
+from aidial_rag.resources.cpu_pools import run_in_embeddings_pool
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +74,7 @@ class AsyncEmbeddings(Embeddings):
         raise NotImplementedError()
 
     async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
-        return await run_in_indexing_embeddings_pool(
+        return await run_in_embeddings_pool(
             bge_embedding_impl().embed_documents, texts
         )
 
@@ -91,7 +88,7 @@ class AsyncEmbeddings(Embeddings):
         ]
 
     async def aembed_query(self, text: str) -> List[float]:
-        return await run_in_query_embeddings_pool(
+        return await run_in_embeddings_pool(
             bge_embedding_impl().embed_query, text
         )
 

--- a/aidial_rag/resources/cpu_pools.py
+++ b/aidial_rag/resources/cpu_pools.py
@@ -22,22 +22,11 @@ class CpuPoolsConfig(BaseConfig):
         description="Process pool for document parsing, image extraction and similar CPU-bound tasks. "
         "Is set to `max(1, CPU_COUNT - 2)` to leave some CPU cores for other tasks.",
     )
-    indexing_embeddings_pool: int = Field(
-        default=1,
-        description="Embedding process itself uses multiple cores. "
-        "Should be `1`, unless you have a lot of cores and can explicitly see "
-        "the underutilisation (i.e. you only have a very small documents in the requests).",
-    )
-    query_embeddings_pool: int = Field(
-        default=1,
-        description="Embedding process for the query. Should be `1`, unless you have a lot of cores.",
-    )
 
 
 class CpuPools:
     indexing_cpu_pool: ThreadPoolExecutor
-    indexing_embeddings_pool: ThreadPoolExecutor
-    query_embeddings_pool: ThreadPoolExecutor
+    embeddings_pool: ThreadPoolExecutor
 
     def __init__(self, config: CpuPoolsConfig) -> None:
         # Using ThreadPoolExecutor instead of ProcessPoolExecutor, because
@@ -47,15 +36,11 @@ class CpuPools:
             thread_name_prefix="indexing_cpu",
         )
 
-        self.indexing_embeddings_pool = ThreadPoolExecutor(
-            max_workers=config.indexing_embeddings_pool,
-            thread_name_prefix="indexing_embeddings",
-        )
-
-        # TODO: Do we need a separate pool for query embeddings?
-        self.query_embeddings_pool = ThreadPoolExecutor(
-            max_workers=config.query_embeddings_pool,
-            thread_name_prefix="query_embeddings",
+        # Use the same pool for query and indexing embeddings
+        # to have a single thread to work with openvino backend
+        self.embeddings_pool = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="embeddings",
         )
 
     def _run_in_pool(self, pool, func, *args, **kwargs):
@@ -66,15 +51,8 @@ class CpuPools:
     def run_in_indexing_cpu_pool(self, func, *args, **kwargs):
         return self._run_in_pool(self.indexing_cpu_pool, func, *args, **kwargs)
 
-    def run_in_indexing_embeddings_pool(self, func, *args, **kwargs):
-        return self._run_in_pool(
-            self.indexing_embeddings_pool, func, *args, **kwargs
-        )
-
-    def run_in_query_embeddings_pool(self, func, *args, **kwargs):
-        return self._run_in_pool(
-            self.query_embeddings_pool, func, *args, **kwargs
-        )
+    def run_in_embeddings_pool(self, func, *args, **kwargs):
+        return self._run_in_pool(self.embeddings_pool, func, *args, **kwargs)
 
     _instance = None
 
@@ -101,21 +79,12 @@ async def init_cpu_pools(config: CpuPoolsConfig):
 
     cpu_pools = CpuPools.init_cpu_pools(config)
     await cpu_pools.run_in_indexing_cpu_pool(sum, range(10))
-    await cpu_pools.run_in_indexing_embeddings_pool(sum, range(10))
-    await cpu_pools.run_in_query_embeddings_pool(sum, range(10))
+    await cpu_pools.run_in_embeddings_pool(sum, range(10))
 
 
 def run_in_indexing_cpu_pool(func, *args, **kwargs):
     return CpuPools.instance().run_in_indexing_cpu_pool(func, *args, **kwargs)
 
 
-def run_in_indexing_embeddings_pool(func, *args, **kwargs):
-    return CpuPools.instance().run_in_indexing_embeddings_pool(
-        func, *args, **kwargs
-    )
-
-
-def run_in_query_embeddings_pool(func, *args, **kwargs):
-    return CpuPools.instance().run_in_query_embeddings_pool(
-        func, *args, **kwargs
-    )
+def run_in_embeddings_pool(func, *args, **kwargs):
+    return CpuPools.instance().run_in_embeddings_pool(func, *args, **kwargs)


### PR DESCRIPTION
### Description of changes

Use the same thread pool for  query and indexing embeddings, to have a single thread working with openvino backend.
Using openvino from multiple threads may cause `Infer Request is busy` error.
Environment variables DIAL_RAG__CPU_POOLS__INDEXING_EMBEDDINGS_POOL and DIAL_RAG__CPU_POOLS__QUERY_EMBEDDINGS_POOL are now deprecated.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
