### PR TITLE
fix: fix sentence_transformers kwargs for gpu device

### DIFF
--- a/aidial_rag/embeddings/local_embeddings.py
+++ b/aidial_rag/embeddings/local_embeddings.py
@@ -30,7 +30,7 @@ BGE_EMBEDDINGS_DEVICE = detect_device(
     os.environ.get("BGE_EMBEDDINGS_DEVICE", DeviceType.AUTO)
 )
 
-MODEL_KWARGS_BY_DEVICE: Dict[str, Any] = {
+SENTENCE_TRANSFORMERS_KWARGS_BY_DEVICE: Dict[str, Any] = {
     DeviceType.CPU: {
         "device": "cpu",
         "backend": "openvino",
@@ -38,8 +38,10 @@ MODEL_KWARGS_BY_DEVICE: Dict[str, Any] = {
     DeviceType.CUDA: {
         "device": "cuda",
         "backend": "torch",
-        "torch_dtype": "float16",
-        "attn_implementation": "sdpa",
+        "model_kwargs": {
+            "torch_dtype": "float16",
+            "attn_implementation": "sdpa",
+        },
     },
 }
 
@@ -54,11 +56,11 @@ class LocalEmbeddingsConfig(BaseConfig):
 
 class LocalEmbeddingsModel(EmbeddingsModel):
     def __init__(self, config: LocalEmbeddingsConfig) -> None:
-        model_kwargs = MODEL_KWARGS_BY_DEVICE[config.device]
+        kwargs = SENTENCE_TRANSFORMERS_KWARGS_BY_DEVICE[config.device]
         self._config = config
         self._model = SentenceTransformer(
             config.model_name_or_path,
-            **model_kwargs,
+            **kwargs,
         )
 
     def _embed_query(self, text: str) -> np.ndarray:


### PR DESCRIPTION
### Description of changes

After #84 , gpu version does not work correctly, because HuggingFaceBgeEmbeddings class did some manipulations with kwargs before passing it to sentence_transformers. Fixing it.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
