### PR TITLE
feat: add text-only config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following configuration files are available in the `config` directory:
 - `config/gcp_description.yaml` - GCP environment with description retriever, which uses `Gemini 2.5 Flash` model for page images descriptions and `Gemini 2.5 Pro` for the answer generation.
 - `config/gcp_embedding.yaml` - GCP environment with multimodal retriever, which uses Google `multimodalembedding@001` model for page images embeddings and `Gemini 2.5 Pro` for the answer generation.
 - `config/azure_with_gcp_embedding.yaml` - mixed environment which assumes that you have and access to both Azure and GCP models in the Dial. It uses Google `multimodalembedding@001` model for page images embeddings and `GPT-4.1` for the answer generation.
+- `config/text_only.yaml` - example of config with text-only mode, where the image-based retrievers are disabled. This config can be used with LLMs which do not support image inputs. Uses `GPT-4.1` for the answer generation by default.
 
 If you are running the Dial RAG in a different environment, you can create your own configuration file based on one of the provided files and set the `DIAL_RAG__CONFIG_PATH` environment variable to point to it. If you need a small change in the configuration (for example to change the model name), you can point the `DIAL_RAG__CONFIG_PATH` to the existing file and override the required settings using the environment variables. See the [Additional environment variables](#additional-environment-variables) section for the list of available settings.
 

--- a/config/text_only.yaml
+++ b/config/text_only.yaml
@@ -1,0 +1,20 @@
+# Example of ai-dial-rag config with text-only models
+#
+# Both image-based retrievers are disabled
+# The num_page_images_to_use is set to 0 to avoid passing images to LLM
+# Can be used with the LLMs which do not support images
+#
+request:
+  indexing:
+    description_index: null
+    multimodal_index: null
+  qa_chain:
+    chat_chain:
+      llm:
+        deployment_name: gpt-4.1-2025-04-14
+        max_prompt_tokens: 16000
+      num_page_images_to_use: 0
+    query_chain:
+      llm:
+        deployment_name: gpt-4.1-2025-04-14
+        max_prompt_tokens: 8000


### PR DESCRIPTION
### Description of changes

Add text-only config for ai-dial-rag. This config disables image-based retrievers and could help to setup RAG with LLMs which do not support images as input.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
