### PR TITLE
chore: add .trivyignore for CVE-2026-34070

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# Vulnerability in langchain load_prompt and load_prompt_from_config: https://github.com/advisories/GHSA-qh6h-p6c9-ff54
+# We do not use load_prompt and load_prompt_from_config in this project.
+CVE-2026-34070 exp:2026-05-31


### PR DESCRIPTION
### Description of changes

Trivy blocks releases because of CVE-2026-34070 in langchain and requires update from langchain 0.3.81 to 1.2.22.
Since we do not use the affected features (load_prompt, load_prompt_from_config, and the .save() method on prompt classes), the  update to a new major langchain versions looks more dangerous for this release.
So, I'm adding CVE-2026-34070 to .trivyignore for now.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
