### PR TITLE
fix: update libreoffice to 25.8.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
         && \
     apt-get install --no-install-recommends -y -t noble-backports \
         # Libreoffice is required for MS office documents
-        libreoffice=4:25.8.5-0ubuntu0.25.10.1~bpo24.04.1 \
+        libreoffice=4:25.8.6-0ubuntu0.25.10.1~bpo24.04.1 \
         && \
     # Cleanup apt cache in the same command to reduce size
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ IMAGE_NAME ?= ai-dial-rag
 PLATFORM ?= linux/amd64
 POETRY ?= poetry
 DOCKER ?= docker
-LIBREOFFICE_UBUNTU_VERSION ?= 4:25.8.5-0ubuntu0.25.10.1~bpo24.04.1
+LIBREOFFICE_UBUNTU_VERSION ?= 4:25.8.6-0ubuntu0.25.10.1~bpo24.04.1
 ARGS ?=
 
 # Check for CI environment


### PR DESCRIPTION
### Description of changes

Libreoffice `4:25.8.5-0ubuntu0.25.10.1~bpo24.04.1` was removed from noble-backports repository after `4:25.8.6-0ubuntu0.25.10.1~bpo24.04.1` has appeared. This causes docker build process to fail.
Updating `libreoffice to 4:25.8.6-0ubuntu0.25.10.1~bpo24.04.1` to fix it.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
